### PR TITLE
update compiler version to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.0.2</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
With compiler version set to 1.5 the project does not compile with modern versions of maven.
Update to 1.8, which is the current lowest supported version for most java projects.
It could be set to 1.7 to be conservative, but 1.8 should be good for master?