### PR TITLE
Use ckf serial session

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.0.2</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/org/pkcs11/jacknji11/CE.java
+++ b/src/main/java/org/pkcs11/jacknji11/CE.java
@@ -330,7 +330,7 @@ public class CE {
     }
 
     /**
-     * Opens a session between an application and a token using {@link CKS#RW_PUBLIC_SESSION}
+     * Opens a session between an application and a token using {@link CK_SESSION_INFO#CKF_RW_SESSION and CK_SESSION_INFO#CKF_SERIAL_SESSION}
      * and null application and notify.
      * @param slotID the slot's ID
      * @return session handle
@@ -338,7 +338,7 @@ public class CE {
      * @see NativeProvider#C_OpenSession(long, long, Pointer, CK_NOTIFY, LongRef)
      */
     public static long OpenSession(long slotID) {
-        return OpenSession(slotID, CKS.RW_PUBLIC_SESSION, null, null);
+        return OpenSession(slotID, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
     }
 
     /**


### PR DESCRIPTION
NativeProvider.C_OpenSession documents that CKF_SERIAL_SESSION is needed, and it is needed for SoftHSM2 at least. Make default OpenSession metod use this flag.