### PR TITLE
Shrink returned byte array to the size reported by p11, if needed

### DIFF
--- a/src/main/java/org/pkcs11/jacknji11/CKA.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKA.java
@@ -259,9 +259,31 @@ public class CKA {
         this(type, null);
     }
 
+    /** Some HSMs return a larger value byte array than the size given by the returned length, so we must handle 
+     * that the actual value is shorter than the size of the byte array.
+     * This method checks if a returned byte array needs to be shrunken to the size P11 says it should be.
+     * 
+     * @param value byte array to copy into return value
+     * @param len length of the possibly shrunken return value
+     * @return value if value.length >= len or a new byte array with length len copied from the len first byte of value
+     */
+    private byte[] getShrunkenValue(byte[] value, long len) {
+        final byte[] ret;
+        if (value != null && len < value.length) {
+            // we have a larger byte array than the actual data, shrink it
+            ret = new byte[(int)len];
+            for (int i = 0; i < ret.length; i++) {
+                ret[i] = value[i];
+            }
+        } else {
+            ret = value;
+        }
+        return ret;
+    }
+    
     /** @return value as byte[] */
     public byte[] getValue() {
-        return pValue == null ? null : pValue;
+        return pValue == null ? null : getShrunkenValue(pValue, ulValueLen);
     }
 
     /** @return value as String */
@@ -299,7 +321,7 @@ public class CKA {
 
     /** @return value as BigInteger */
     public BigInteger getValueBigInt() {
-        return ulValueLen == 0 || pValue == null ? null : new BigInteger(getValue());
+        return ulValueLen == 0 || pValue == null ? null : new BigInteger(getShrunkenValue(pValue, ulValueLen));
     }
 
     /**

--- a/src/main/java/org/pkcs11/jacknji11/CKA.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKA.java
@@ -259,31 +259,9 @@ public class CKA {
         this(type, null);
     }
 
-    /** Some HSMs return a larger value byte array than the size given by the returned length, so we must handle 
-     * that the actual value is shorter than the size of the byte array.
-     * This method checks if a returned byte array needs to be shrunken to the size P11 says it should be.
-     * 
-     * @param value byte array to copy into return value
-     * @param len length of the possibly shrunken return value
-     * @return value if value.length >= len or a new byte array with length len copied from the len first byte of value
-     */
-    private byte[] getShrunkenValue(byte[] value, long len) {
-        final byte[] ret;
-        if (value != null && len < value.length) {
-            // we have a larger byte array than the actual data, shrink it
-            ret = new byte[(int)len];
-            for (int i = 0; i < ret.length; i++) {
-                ret[i] = value[i];
-            }
-        } else {
-            ret = value;
-        }
-        return ret;
-    }
-    
     /** @return value as byte[] */
     public byte[] getValue() {
-        return pValue == null ? null : getShrunkenValue(pValue, ulValueLen);
+        return pValue == null ? null : pValue;
     }
 
     /** @return value as String */
@@ -321,7 +299,7 @@ public class CKA {
 
     /** @return value as BigInteger */
     public BigInteger getValueBigInt() {
-        return ulValueLen == 0 || pValue == null ? null : new BigInteger(getShrunkenValue(pValue, ulValueLen));
+        return ulValueLen == 0 || pValue == null ? null : new BigInteger(getValue());
     }
 
     /**

--- a/src/main/java/org/pkcs11/jacknji11/CKA.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKA.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.pkcs11.jacknji11.Buf;
 
 /**
  * CKA_? constants and wrapper for CK_ATTRIBUTE struct.
@@ -299,7 +300,7 @@ public class CKA {
 
     /** @return value as BigInteger */
     public BigInteger getValueBigInt() {
-        return ulValueLen == 0 || pValue == null ? null : new BigInteger(getValue());
+        return ulValueLen == 0 || pValue == null ? null : new BigInteger(Buf.substring(pValue, 0, (int)ulValueLen));
     }
 
     /**


### PR DESCRIPTION
Some HSMs (namely Cavium as I just found out), returns as CKA a byte array that is loner than the actual value, and expects the caller to resize the returned value to the returned length before using it (for example decoding as a Big Integer). If we don't resize the byte array, returning a BigInteger will return the wrong value (for example RSA public key exponent).
This patch resizes what the byte array we use in Java to the correct size, if needed.