### PR TITLE
make tests pass on more HSMs, which are differently picky on attributes

### DIFF
--- a/src/test/java/org/pkcs11/jacknji11/CryptokiTest.java
+++ b/src/test/java/org/pkcs11/jacknji11/CryptokiTest.java
@@ -156,7 +156,7 @@ public class CryptokiTest extends TestCase {
         CKA[] templ = {
             new CKA(CKA.CLASS, CKO.DATA),
             new CKA(CKA.PRIVATE, false),
-            new CKA(CKA.VALUE, "datavalue".getBytes(StandardCharsets.UTF_8)),
+            new CKA(CKA.VALUE, "datavalue"),
         };
         long o = CE.CreateObject(session, templ);
         long size = CE.GetObjectSize(session, o);
@@ -168,7 +168,7 @@ public class CryptokiTest extends TestCase {
         templ = new CKA[] {
                 // Different HSMs are pick in different ways which attributes can be modified, 
                 // just modify label which seems to work on most
-                new CKA(CKA.LABEL, "datalabel".getBytes(StandardCharsets.UTF_8)),
+                new CKA(CKA.LABEL, "datalabel"),
         };
         CE.SetAttributeValue(session, o, templ);
         long newsize = CE.GetObjectSize(session, o);


### PR DESCRIPTION
Different HSMs are differently picky on attributes. This pull request makes the tests pass on more HSMs. I think it still tests the functionality enough. I.e. SoftHSM return -1 for object size always....