### PR TITLE
add bin to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .settings
 logs
 target
+/bin/


### PR DESCRIPTION
I use eclipse and it (and many other IDEs I think?) builds things by default into bin/. Add bin to gitignore to make it easier to work in eclipse.