### PR TITLE
correct link to jna

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Java-styled interface providing convenience methods and using
 exceptions for error handling.
 
 Uses a provider architecture to allow any implementation of the 
-native mapping.  Includes JNA < https://github.com/twall/jna > 
+native mapping. Includes JNA < https://github.com/java-native-access/jna > 
 as default provider to bridge between Java and native cryptoki lib.
 
 # Install


### PR DESCRIPTION
The link to the JNA project has changed, just update README with the correct link.