### PR TITLE
Use null as argument to JNA if notify is null

### DIFF
--- a/src/main/java/org/pkcs11/jacknji11/jna/JNA.java
+++ b/src/main/java/org/pkcs11/jacknji11/jna/JNA.java
@@ -141,11 +141,16 @@ public class JNA implements NativeProvider {
 
     public long C_OpenSession(long slotID, long flags, NativePointer application, final CK_NOTIFY notify, LongRef phSession) {
         Pointer jna_application = new Pointer(application.getAddress());
-        JNA_CK_NOTIFY jna_notify = new JNA_CK_NOTIFY() {
-            public NativeLong invoke(NativeLong hSession, NativeLong event, Pointer pApplication) {
-                return NL(notify.invoke(hSession.longValue(), event.longValue(), new NativePointer(Pointer.nativeValue(pApplication))));
-            }
-        };
+        final JNA_CK_NOTIFY  jna_notify;
+        if (notify == null) {
+            jna_notify = null; 
+        } else {
+            jna_notify = new JNA_CK_NOTIFY() {
+                public NativeLong invoke(NativeLong hSession, NativeLong event, Pointer pApplication) {
+                    return NL(notify.invoke(hSession.longValue(), event.longValue(), new NativePointer(Pointer.nativeValue(pApplication))));
+                }
+            };
+        }
         NativeLongByReference jna_phSession = NLP(phSession.value);
         long rv = jnaNative.C_OpenSession(NL(slotID), NL(flags), jna_application, jna_notify, jna_phSession);
         application.setAddress(Pointer.nativeValue(jna_application));


### PR DESCRIPTION
Some P11 providers (AWS CloudHSM new driver) does not support notify and will fail C_OpenSession with the current code with the following message:
2021-05-21T18:51:06.710Z ERROR [11033] ThreadId(3) [cloudhsm_pkcs11::session::C_OpenSession] Notify callback function is not supported, please pass in NULL_PTR for both pApplication and Notify
2021-05-21T18:51:06.710Z ERROR [11033] ThreadId(3) [cloudhsm_pkcs11::session::C_OpenSession] C_OpenSession failed, returning 0x00000007

Simply passing null to JNA OpenSession will make it work.