### PR TITLE
Keep Memory objects to prevent them from being removed in GC

### DIFF
--- a/src/main/java/org/pkcs11/jacknji11/jna/Template.java
+++ b/src/main/java/org/pkcs11/jacknji11/jna/Template.java
@@ -21,6 +21,9 @@
 
 package org.pkcs11.jacknji11.jna;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.pkcs11.jacknji11.CKA;
 
 import com.sun.jna.Memory;
@@ -39,6 +42,7 @@ import com.sun.jna.PointerType;
  */
 public class Template extends PointerType {
     private CKA[] list;
+    private List<Memory> pValues;
     private int listLen;
 
     /** Default no-arg constructor required by JNA. */
@@ -57,6 +61,8 @@ public class Template extends PointerType {
             return;
         }
         setPointer(new Memory(listLen * (NativeLong.SIZE + Native.POINTER_SIZE + NativeLong.SIZE)));
+        // Keep java references over the life time of this Template to avoid native memory being freed before use
+        pValues = new ArrayList<>();
         int offset = 0;
 
         for (int i = 0; i < listLen; i++) {
@@ -75,6 +81,10 @@ public class Template extends PointerType {
                 pValue.write(0, list[i].pValue, 0, (int) list[i].ulValueLen);
             }
             getPointer().setPointer(offset, pValue);
+            // We saved a "long" pointer to the memory allocated by "new Memory" above, keep the java object 
+            // reference as well to avoid it being garbage collected, which will free the native memory allocated when
+            // Memory.finalize is called
+            pValues.add(pValue);
             offset += Native.POINTER_SIZE;
 
             // ulValueLen


### PR DESCRIPTION
In Template.java native memory is being allocated through the JNA Memory object, these objects are however just local to the constructor. Since Memory uses a finalize() method to free native memory it then happens (randomly under load of course) that it's garbage collected followed by a seg-fault with read-after-free when the Template CKA values are read. Keeping the Memory object around for as long as the Template object is around seems to avoids this.