### PR TITLE
Add equals and hashCode to CKA to enable usage in java stream

### DIFF
--- a/src/main/java/org/pkcs11/jacknji11/CKA.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKA.java
@@ -22,6 +22,7 @@
 package org.pkcs11.jacknji11;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.Map;
 
 import org.apache.commons.logging.Log;
@@ -425,4 +426,33 @@ public class CKA {
         dump(sb);
         return sb.toString();
     }
+    
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Arrays.hashCode(pValue);
+        result = prime * result + (int) (type ^ (type >>> 32));
+        result = prime * result + (int) (ulValueLen ^ (ulValueLen >>> 32));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        CKA other = (CKA) obj;
+        if (!Arrays.equals(pValue, other.pValue))
+            return false;
+        if (type != other.type)
+            return false;
+        if (ulValueLen != other.ulValueLen)
+            return false;
+        return true;
+    }
+
 }


### PR DESCRIPTION
By adding equals and hashCode to CKA we can use java streams for some cool operations like:

        final List<CKA> ckasAsList = Arrays.stream(ckas).collect(toList());
        final List<Long> objectRefsFromCache = cache.stream()
                .map(attribute -> attribute.objectRef)
                .distinct()
                .filter(objectRef -> hasAllAttributes(objectRef, ckasAsList))
                .collect(toList());
