### PR TITLE
Implement "instance" versions of C and CE classes (#44). Alternative implementation. 

### DIFF
--- a/src/main/java/org/pkcs11/jacknji11/C.java
+++ b/src/main/java/org/pkcs11/jacknji11/C.java
@@ -58,33 +58,24 @@ import org.pkcs11.jacknji11.jna.JNA;
  * </ol>
  *
  * @author Joel Hockey (joel.hockey@gmail.com)
+ * @deprecated Use the {@link Ci} class instead
  */
+@Deprecated
 public class C {
-    private static final Log log = LogFactory.getLog(C.class);
-
-    public static NativeProvider NATIVE;
-
-    private static final NativePointer NULL = new NativePointer(0);
 
     /**
-     * Read custom libarary from environment JACKNJI11_PKCS11_LIB_PATH,
-     * or use default 'cryptoki'.
-     * @return libarary name
+     * @deprecated Use the {@link Ci} class instead.
      */
-    public static String getLibraryName() {
-        String lib = System.getenv("JACKNJI11_PKCS11_LIB_PATH");
-        if (lib == null || lib.length() == 0) {
-            lib = "cryptoki";
-        }
-        log.debug("Loading native library " + lib);
-        return lib;
-    }
+    @Deprecated
+    static NativeProvider NATIVE;
 
     /**
      * Initialise Cryptoki with null mutexes, and CKF_OS_LOCKING_OK flag set.
      * @see NativeProvider#C_Initialize(CK_C_INITIALIZE_ARGS)
      * @return {@link CKR} return code
+     * @deprecated use {@link Ci#Initialize()} instead
      */
+    @Deprecated
     public static long Initialize() {
         CK_C_INITIALIZE_ARGS args = new CK_C_INITIALIZE_ARGS(null, null, null, null,
                 CK_C_INITIALIZE_ARGS.CKF_OS_LOCKING_OK);
@@ -95,27 +86,25 @@ public class C {
      * Initialise Cryptoki with supplied args.
      * @see NativeProvider#C_Initialize(CK_C_INITIALIZE_ARGS)
      * @return {@link CKR} return code
+     * @deprecated use {@link Ci#Initialize(CK_C_INITIALIZE_ARGS)} instead
      */
+    @Deprecated
     public static long Initialize(CK_C_INITIALIZE_ARGS pInitArgs) {
         if (NATIVE == null) {
             NATIVE = new JNA();
         }
-        if (log.isDebugEnabled()) log.debug("> C_Initialize " + pInitArgs);
-        long rv =NATIVE.C_Initialize(pInitArgs);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_Initialize rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.Initialize(NATIVE, pInitArgs);
     }
 
     /**
      * Called to indicate that an application is finished with the Cryptoki library.
      * @see NativeProvider#C_Finalize(NativePointer)
      * @return {@link CKR} return code
+     * @deprecated use {@link Ci#Finalize()} instead
      */
+    @Deprecated
     public static long Finalize() {
-        if (log.isDebugEnabled()) log.debug("> C_Finalize");
-        long rv =NATIVE.C_Finalize(NULL);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_Finalize rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.Finalize(NATIVE);
     }
 
     /**
@@ -123,12 +112,11 @@ public class C {
      * @param info location that receives information
      * @return {@link CKR} return code
      * @see NativeProvider#C_GetInfo(CK_INFO)
+     * @deprecated use {@link Ci#GetInfo(CK_INFO)} instead
      */
+    @Deprecated
     public static long GetInfo(CK_INFO info) {
-        if (log.isDebugEnabled()) log.debug("> C_GetInfo");
-        long rv =NATIVE.C_GetInfo(info);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_GetInfo rv=0x%08x{%s}\n%s", rv, CKR.L2S(rv), info));
-        return rv;
+        return NC.GetInfo(NATIVE, info);
     }
 
     /**
@@ -137,13 +125,12 @@ public class C {
      * @param slotList receives array of slot IDs
      * @param count receives the number of slots
      * @return {@link CKR} return code
-     * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef) 
+     * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef)
+     * @deprecated use {@link Ci#GetSlotList(boolean, long[], LongRef)} instead
      */
+    @Deprecated
     public static long GetSlotList(boolean tokenPresent, long[] slotList, LongRef count) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_GetSlotList tokenPresent=%b count=%d", tokenPresent, count.value()));
-        long rv =NATIVE.C_GetSlotList(tokenPresent, slotList, count);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_GetSlotList rv=0x%08x{%s} count=%d\n  %s", rv, CKR.L2S(rv), count.value(), Arrays.toString(slotList)));
-        return rv;
+        return NC.GetSlotList(NATIVE, tokenPresent, slotList, count);
     }
 
     /**
@@ -152,12 +139,11 @@ public class C {
      * @param info receives the slot information
      * @return {@link CKR} return code
      * @see NativeProvider#C_GetSlotInfo(long, CK_SLOT_INFO)
+     * @deprecated use {@link Ci#GetSlotInfo(long, CK_SLOT_INFO)} instead
      */
+    @Deprecated
     public static long GetSlotInfo(long slotID, CK_SLOT_INFO info) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_GetSlotInfo slotID=%d", slotID));
-        long rv =NATIVE.C_GetSlotInfo(slotID, info);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_GetSlotInfo rv=0x%08x{%s}\n%s", rv, CKR.L2S(rv), info));
-        return rv;
+        return NC.GetSlotInfo(NATIVE, slotID, info);
     }
 
     /**
@@ -166,12 +152,11 @@ public class C {
      * @param info receives the token information
      * @return {@link CKR} return code
      * @see NativeProvider#C_GetTokenInfo(long, CK_TOKEN_INFO)
+     * @deprecated use {@link Ci#GetTokenInfo(long, CK_TOKEN_INFO)} instead
      */
+    @Deprecated
     public static long GetTokenInfo(long slotID, CK_TOKEN_INFO info) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_GetTokenInfo slotID=%d", slotID));
-        long rv =NATIVE.C_GetTokenInfo(slotID, info);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_GetTokenInfo rv=0x%08x{%s}\n%s", rv, CKR.L2S(rv), info));
-        return rv;
+        return NC.GetTokenInfo(NATIVE, slotID, info);
     }
 
     /**
@@ -181,12 +166,11 @@ public class C {
      * @param reserved reserved.  Should be null
      * @return {@link CKR} return code
      * @see NativeProvider#C_WaitForSlotEvent(long, LongRef, NativePointer)
+     * @deprecated use {@link Ci#WaitForSlotEvent(long, LongRef, NativePointer)} instead
      */
+    @Deprecated
     public static long WaitForSlotEvent(long flags, LongRef slot, NativePointer reserved) {
-        if (log.isDebugEnabled()) log.debug("> C_WaitForSlotEvent");
-        long rv =NATIVE.C_WaitForSlotEvent(flags, slot, reserved != null ? reserved : NULL);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_WaitForSlotEvent rv=0x%08x{%s} slot=%d", rv, CKR.L2S(rv), slot.value()));
-        return rv;
+        return NC.WaitForSlotEvent(NATIVE, flags, slot, reserved);
     }
 
     /**
@@ -196,21 +180,11 @@ public class C {
      * @param count gets # of mechanisms
      * @return {@link CKR} return code
      * @see NativeProvider#C_GetMechanismList(long, long[], LongRef)
+     * @deprecated use {@link Ci#GetMechanismList(long, long[], LongRef)} instead
      */
+    @Deprecated
     public static long GetMechanismList(long slotID, long[] mechanismList, LongRef count) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_GetMechanismList slotID=%d count=%d", slotID, count.value()));
-        long rv =NATIVE.C_GetMechanismList(slotID, mechanismList, count);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_GetMechanismList rv=0x%08x{%s} count=%d", rv, CKR.L2S(rv), count.value()));
-            if (mechanismList != null) {
-                sb.append('\n');
-                for (long m : mechanismList) {
-                    sb.append(String.format("  0x%08x{%s}\n", m, CKM.L2S(m)));
-                }
-            }
-            log.debug(sb);
-        }
-        return rv;
+        return NC.GetMechanismList(NATIVE, slotID, mechanismList, count);
     }
 
     /**
@@ -220,12 +194,11 @@ public class C {
      * @param info receives mechanism info
      * @return {@link CKR} return code
      * @see NativeProvider#C_GetMechanismInfo(long, long, CK_MECHANISM_INFO)
+     * @deprecated use {@link Ci#GetMechanismInfo(long, long, CK_MECHANISM_INFO)} instead
      */
+    @Deprecated
     public static long GetMechanismInfo(long slotID, long type, CK_MECHANISM_INFO info) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_GetMechanismInfo slotID=%d type=0x%08x{%s}", slotID, type, CKM.L2S(type)));
-        long rv =NATIVE.C_GetMechanismInfo(slotID, type, info);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_GetMechanismInfo rv=0x%08x{%s}\n%s", rv, CKR.L2S(rv), info));
-        return rv;
+        return NC.GetMechanismInfo(NATIVE, slotID, type, info);
     }
 
     /**
@@ -236,22 +209,11 @@ public class C {
      * it will be padded or truncated as required
      * @return {@link CKR} return code
      * @see NativeProvider#C_InitToken(long, byte[], long, byte[])
+     * @deprecated use {@link Ci#InitToken(long, byte[], byte[])} instead
      */
+    @Deprecated
     public static long InitToken(long slotID, byte[] pin, byte[] label) {
-        byte[] label32;
-        if (label != null && label.length == 32) {
-            label32 = label;
-        } else {
-            label32 = new byte[32];
-            Arrays.fill(label32, (byte) 0x20); // space fill
-            if (label != null) {
-                System.arraycopy(label, 0, label32, 0, Math.min(label32.length, label.length));
-            }
-        }
-        if (log.isDebugEnabled()) log.debug(String.format("> C_InitToken slotID=%d pin=*** label=%s", slotID, Buf.escstr(label32)));
-        long rv =NATIVE.C_InitToken(slotID, pin, baLen(pin), label32);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_InitToken rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.InitToken(NATIVE, slotID, pin, label);
     }
 
     /**
@@ -260,12 +222,11 @@ public class C {
      * @param pin the normal user's PIN
      * @return {@link CKR} return code
      * @see NativeProvider#C_InitPIN(long, byte[], long)
+     * @deprecated use {@link Ci#InitPIN(long, byte[])} instead
      */
+    @Deprecated
     public static long InitPIN(long session, byte[] pin) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_InitPIN session=0x%08x pin=***", session));
-        long rv =NATIVE.C_InitPIN(session, pin, baLen(pin));
-        if (log.isDebugEnabled()) log.debug(String.format("< C_InitPIN rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.InitPIN(NATIVE, session, pin);
     }
 
     /**
@@ -275,12 +236,11 @@ public class C {
      * @param newPin new PIN
      * @return {@link CKR} return code
      * @see NativeProvider#C_SetPIN(long, byte[], long, byte[], long)
+     * @deprecated use {@link Ci#SetPIN(long, byte[], byte[])} instead
      */
+    @Deprecated
     public static long SetPIN(long session, byte[] oldPin, byte[] newPin) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_SetPIN session=0x%08x oldPin=*** newPin=***", session));
-        long rv =NATIVE.C_SetPIN(session, oldPin, baLen(oldPin), newPin, baLen(newPin));
-        if (log.isDebugEnabled()) log.debug(String.format("< C_SetPIN rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.SetPIN(NATIVE, session, oldPin, newPin);
     }
 
     /**
@@ -292,12 +252,11 @@ public class C {
      * @param session gets session handle
      * @return {@link CKR} return code
      * @see NativeProvider#C_OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
+     * @deprecated use {@link Ci#OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)} instead
      */
+    @Deprecated
     public static long OpenSession(long slotID, long flags, NativePointer application, CK_NOTIFY notify, LongRef session) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_OpenSession slotID=%d flags=0x%08x{%s} application=%s notify=%s", slotID, flags, CK_SESSION_INFO.f2s(flags), application, notify));
-        long rv =NATIVE.C_OpenSession(slotID, flags, application != null ? application : NULL, notify, session);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_OpenSession rv=0x%08x{%s} session=0x%08x", rv, CKR.L2S(rv), session.value()));
-        return rv;
+        return NC.OpenSession(NATIVE, slotID, flags, application, notify, session);
     }
 
     /**
@@ -305,12 +264,11 @@ public class C {
      * @param session the session's handle
      * @return {@link CKR} return code
      * @see NativeProvider#C_CloseSession(long)
+     * @deprecated use {@link Ci#CloseSession(long)} instead
      */
+    @Deprecated
     public static long CloseSession(long session) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_CloseSession session=0x%08x", session));
-        long rv =NATIVE.C_CloseSession(session);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_CloseSession rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.CloseSession(NATIVE, session);
     }
 
     /**
@@ -318,12 +276,11 @@ public class C {
      * @param slotID the token's slot
      * @return {@link CKR} return code
      * @see NativeProvider#C_CloseAllSessions(long)
+     * @deprecated use {@link Ci#CloseAllSessions(long)} instead
      */
+    @Deprecated
     public static long CloseAllSessions(long slotID) {
-        if (log.isDebugEnabled()) log.debug("> C_CloseAllSessions");
-        long rv =NATIVE.C_CloseAllSessions(slotID);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_CloseAllSessions rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.CloseAllSessions(NATIVE, slotID);
     }
 
     /**
@@ -332,12 +289,11 @@ public class C {
      * @param info receives session info
      * @return {@link CKR} return code
      * @see NativeProvider#C_GetSessionInfo(long, CK_SESSION_INFO)
+     * @deprecated use {@link Ci#GetSessionInfo(long, CK_SESSION_INFO)} instead
      */
+    @Deprecated
     public static long GetSessionInfo(long session, CK_SESSION_INFO info) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_GetSessionInfo session=0x%08x", session));
-        long rv =NATIVE.C_GetSessionInfo(session, info);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_GetSessionInfo rv=0x%08x{%s}\n%s", rv, CKR.L2S(rv), info));
-        return rv;
+        return NC.GetSessionInfo(NATIVE, session, info);
     }
 
     /**
@@ -347,18 +303,11 @@ public class C {
      * @param operationStateLen gets state length
      * @return {@link CKR} return code
      * @see NativeProvider#C_GetOperationState(long, byte[], LongRef)
+     * @deprecated use {@link Ci#GetOperationState(long, byte[], LongRef)} instead
      */
+    @Deprecated
     public static long GetOperationState(long session, byte[] operationState, LongRef operationStateLen) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_GetOperationState session=0x%08x operationStateLen=%d", session, operationStateLen.value()));
-        long rv =NATIVE.C_GetOperationState(session, operationState, operationStateLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_GetOperationState rv=0x%08x{%s}\n  operationState (len=%d):\n", rv, CKR.L2S(rv), operationStateLen.value()));
-            if (operationState != null) {
-                Hex.dump(sb, operationState, 0, (int) operationStateLen.value(), "  ", 32, false);
-            }
-            log.debug(sb);
-        }
-        return rv;
+        return NC.GetOperationState(NATIVE, session, operationState, operationStateLen);
     }
 
     /**
@@ -369,21 +318,12 @@ public class C {
      * @param authenticationKey sign/verify key
      * @return {@link CKR} return code
      * @see NativeProvider#C_SetOperationState(long, byte[], long, long, long)
+     * @deprecated use {@link Ci#SetOperationState(long, byte[], long, long)} instead
      */
+    @Deprecated
     public static long SetOperationState(long session, byte[] operationState,
             long encryptionKey, long authenticationKey) {
-
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format(
-                    "> C_SetOperationState session=0x%08x encryptionKey=0x%08x authenticationKey=0x%08x\n  operationState (len=%d):\n",
-                    session, encryptionKey, authenticationKey, operationState.length));
-            Hex.dump(sb, operationState, 0, operationState.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_SetOperationState(session, operationState, baLen(operationState),
-                encryptionKey, authenticationKey);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_SetOperationState rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.SetOperationState(NATIVE, session, operationState, encryptionKey, authenticationKey);
     }
 
     /**
@@ -393,12 +333,11 @@ public class C {
      * @param pin the user's PIN
      * @return {@link CKR} return code
      * @see NativeProvider#C_Login(long, long, byte[], long)
+     * @deprecated use {@link Ci#Login(long, long, byte[])} instead
      */
+    @Deprecated
     public static long Login(long session, long userType, byte[] pin) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_Login session=0x%08x userType=0x%08x{%s} pin=***", session, userType, CKU.L2S(userType)));
-        long rv =NATIVE.C_Login(session, userType, pin, baLen(pin));
-        if (log.isDebugEnabled()) log.debug(String.format("< C_Login rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.Login(NATIVE, session, userType, pin);
     }
 
     /**
@@ -406,12 +345,11 @@ public class C {
      * @param session the session's handle
      * @return {@link CKR} return code
      * @see NativeProvider#C_Logout(long)
+     * @deprecated use {@link Ci#Logout(long)} instead
      */
+    @Deprecated
     public static long Logout(long session) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_Logout session=0x%08x", session));
-        long rv =NATIVE.C_Logout(session);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_Logout rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.Logout(NATIVE, session);
     }
 
     /**
@@ -421,16 +359,11 @@ public class C {
      * @param object gets new object's handle
      * @return {@link CKR} return code
      * @see NativeProvider#C_CreateObject(long, CKA[], long, LongRef)
+     * @deprecated use {@link Ci#CreateObject(long, CKA[], LongRef)} instead
      */
+    @Deprecated
     public static long CreateObject(long session, CKA[] templ, LongRef object) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_CreateObject session=0x%08x\n", session));
-            dumpTemplate(sb, templ);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_CreateObject(session, templ, templLen(templ), object);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_CreateObject rv=0x%08x{%s} object=0x%08x", rv, CKR.L2S(rv), object.value()));
-        return rv;
+        return NC.CreateObject(NATIVE, session, templ, object);
     }
 
     /**
@@ -441,16 +374,11 @@ public class C {
      * @param newObject receives handle of copy
      * @return {@link CKR} return code
      * @see NativeProvider#C_CopyObject(long, long, CKA[], long, LongRef)
+     * @deprecated use {@link Ci#CopyObject(long, long, CKA[], LongRef)} instead
      */
+    @Deprecated
     public static long CopyObject(long session, long object, CKA[] templ, LongRef newObject) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_CopyObject session=0x%08x object=0x%08x\n", session, object));
-            dumpTemplate(sb, templ);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_CopyObject(session, object, templ, templLen(templ), newObject);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_CopyObject rv=0x%08x{%s} newObject=0x%08x", rv, CKR.L2S(rv), newObject.value()));
-        return rv;
+        return NC.CopyObject(NATIVE, session, object, templ, newObject);
     }
 
     /**
@@ -459,12 +387,11 @@ public class C {
      * @param object the object's handle
      * @return {@link CKR} return code
      * @see NativeProvider#C_DestroyObject(long, long)
+     * @deprecated use {@link Ci#DestroyObject(long, long)} instead
      */
+    @Deprecated
     public static long DestroyObject(long session, long object) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_DestroyObject session=0x%08x object=0x%08x", session, object));
-        long rv =NATIVE.C_DestroyObject(session, object);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_DestroyObject rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.DestroyObject(NATIVE, session, object);
     }
 
     /**
@@ -474,12 +401,11 @@ public class C {
      * @param size receives the size of object
      * @return {@link CKR} return code
      * @see NativeProvider#C_GetObjectSize(long, long, LongRef)
+     * @deprecated use {@link Ci#GetObjectSize(long, long, LongRef)} instead
      */
+    @Deprecated
     public static long GetObjectSize(long session, long object, LongRef size) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_GetObjectSize session=0x%08x object=0x%08x", session, object));
-        long rv =NATIVE.C_GetObjectSize(session, object, size);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_GetObjectSize rv=0x%08x{%s} size=%d", rv, CKR.L2S(rv), size.value()));
-        return rv;
+        return NC.GetObjectSize(NATIVE, session, object, size);
     }
 
     /**
@@ -489,20 +415,11 @@ public class C {
      * @param templ specifies attributes, gets values
      * @return {@link CKR} return code
      * @see NativeProvider#C_GetAttributeValue(long, long, CKA[], long)
+     * @deprecated use {@link Ci#GetAttributeValue(long, long, CKA[])} instead
      */
+    @Deprecated
     public static long GetAttributeValue(long session, long object, CKA[] templ) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_GetAttributeValue session=0x%08x object=0x%08x\n", session, object));
-            dumpTemplate(sb, templ);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_GetAttributeValue(session, object, templ, templLen(templ));
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_GetAttributeValue rv=0x%08x{%s}\n", rv, CKR.L2S(rv)));
-            dumpTemplate(sb, templ);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.GetAttributeValue(NATIVE, session, object, templ);
     }
 
     /**
@@ -512,16 +429,11 @@ public class C {
      * @param templ specifies attributes and values
      * @return {@link CKR} return code
      * @see NativeProvider#C_SetAttributeValue(long, long, CKA[], long)
+     * @deprecated use {@link Ci#SetAttributeValue(long, long, CKA[])} instead
      */
+    @Deprecated
     public static long SetAttributeValue(long session, long object, CKA[] templ) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_SetAttributeValue session=0x%08x object=0x%08x\n", session, object));
-            dumpTemplate(sb, templ);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_SetAttributeValue(session, object, templ, templLen(templ));
-        if (log.isDebugEnabled()) log.debug(String.format("< C_SetAttributeValue rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.SetAttributeValue(NATIVE, session, object, templ);
     }
 
     /**
@@ -530,16 +442,11 @@ public class C {
      * @param templ attribute values to match
      * @return {@link CKR} return code
      * @see NativeProvider#C_FindObjectsInit(long, CKA[], long)
+     * @deprecated use {@link Ci#FindObjectsInit(long, CKA[])} instead
      */
+    @Deprecated
     public static long FindObjectsInit(long session, CKA[] templ) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_FindObjectsInit session=0x%08x\n", session));
-            dumpTemplate(sb, templ);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_FindObjectsInit(session, templ, templLen(templ));
-        if (log.isDebugEnabled()) log.debug(String.format("< C_FindObjectsInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.FindObjectsInit(NATIVE, session, templ);
     }
 
     /**
@@ -550,21 +457,11 @@ public class C {
      * @param objectCount number of object handles returned
      * @return {@link CKR} return code
      * @see NativeProvider#C_FindObjects(long, long[], long, LongRef)
+     * @deprecated use {@link Ci#FindObjects(long, long[], LongRef)} instead
      */
+    @Deprecated
     public static long FindObjects(long session, long[] found, LongRef objectCount) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_FindObjects session=0x%08x maxObjectCount=%d", session, found != null ? found.length : 0));
-        long rv = NATIVE.C_FindObjects(session, found, found == null ? 0 : found.length, objectCount);
-        if (log.isDebugEnabled()) {
-            int l = (int) objectCount.value();
-            // only debug found[0:l]
-            long[] toDisplay = found;
-            if (l < found.length) {
-                toDisplay = new long[l];
-                System.arraycopy(found, 0, toDisplay, 0, l);
-            }
-            log.debug(String.format("< C_FindObjects rv=0x%08x{%s} objectCount=%d\n  %s", rv, CKR.L2S(rv), objectCount.value(), Arrays.toString(toDisplay)));
-        }
-        return rv;
+        return NC.FindObjects(NATIVE, session, found, objectCount);
     }
 
     /**
@@ -572,12 +469,11 @@ public class C {
      * @param session the session's handle
      * @return {@link CKR} return code
      * @see NativeProvider#C_FindObjectsFinal(long)
+     * @deprecated use {@link Ci#FindObjectsFinal(long)} instead
      */
+    @Deprecated
     public static long FindObjectsFinal(long session) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_FindObjectsFinal session=0x%08x", session));
-        long rv =NATIVE.C_FindObjectsFinal(session);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_FindObjectsFinal rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.FindObjectsFinal(NATIVE, session);
     }
 
     /**
@@ -587,12 +483,11 @@ public class C {
      * @param key handle of encryption key
      * @return {@link CKR} return code
      * @see NativeProvider#C_EncryptInit(long, CKM, long)
+     * @deprecated use {@link Ci#EncryptInit(long, CKM, long)} instead
      */
+    @Deprecated
     public static long EncryptInit(long session, CKM mechanism, long key) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_EncryptInit session=0x%08x key=0x%08x\n  %s", session, key, mechanism));
-        long rv =NATIVE.C_EncryptInit(session, mechanism, key);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_EncryptInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.EncryptInit(NATIVE, session, mechanism, key);
     }
 
     /**
@@ -603,20 +498,11 @@ public class C {
      * @param encryptedDataLen gets c-text size
      * @return {@link CKR} return code
      * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link Ci#Encrypt(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static long Encrypt(long session, byte[] data, byte[] encryptedData, LongRef encryptedDataLen) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_Encrypt session=0x%08x encryptedDataLen=%d data\n  (len=%d):\n", session, encryptedDataLen.value(), data.length));
-            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_Encrypt(session, data, baLen(data), encryptedData, encryptedDataLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_Encrypt rv=0x%08x{%s}\n  encryptedData (len=%d):\n", rv, CKR.L2S(rv), encryptedDataLen.value()));
-            Hex.dump(sb, encryptedData, 0, (int) encryptedDataLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.Encrypt(NATIVE, session, data, encryptedData, encryptedDataLen);
     }
 
     /**
@@ -627,20 +513,11 @@ public class C {
      * @param encryptedPartLen gets c-text size
      * @return {@link CKR} return code
      * @see NativeProvider#C_EncryptUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link Ci#EncryptUpdate(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static long EncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_EncryptUpdate session=0x%08x encryptedPartLen=%d\n  part (len=%d):\n", session, encryptedPartLen.value(), part.length));
-            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_EncryptUpdate(session, part, baLen(part), encryptedPart, encryptedPartLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_EncryptUpdate rv=0x%08x{%s}\n  encryptedPart (len=%d):\n", rv, CKR.L2S(rv), encryptedPartLen.value()));
-            Hex.dump(sb, encryptedPart, 0, (int) encryptedPartLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.EncryptUpdate(NATIVE, session, part, encryptedPart, encryptedPartLen);
     }
 
     /**
@@ -650,16 +527,11 @@ public class C {
      * @param lastEncryptedPartLen gets last size
      * @return {@link CKR} return code
      * @see NativeProvider#C_EncryptFinal(long, byte[], LongRef)
+     * @deprecated use {@link Ci#EncryptFinal(long, byte[], LongRef)} instead
      */
+    @Deprecated
     public static long EncryptFinal(long session, byte[] lastEncryptedPart, LongRef lastEncryptedPartLen) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_EncryptFinal session=0x%08x lastEncryptedPartLen=%d", session, lastEncryptedPartLen.value()));
-        long rv =NATIVE.C_EncryptFinal(session, lastEncryptedPart, lastEncryptedPartLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_EncryptFinal rv=0x%08x{%s}\n  lastEncryptedPart (len=%d):\n", rv, CKR.L2S(rv), lastEncryptedPartLen.value()));
-            Hex.dump(sb, lastEncryptedPart, 0, (int) lastEncryptedPartLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.EncryptFinal(NATIVE, session, lastEncryptedPart, lastEncryptedPartLen);
     }
 
     /**
@@ -669,12 +541,11 @@ public class C {
      * @param key handle of decryption key
      * @return {@link CKR} return code
      * @see NativeProvider#C_DecryptInit(long, CKM, long)
+     * @deprecated use {@link Ci#DecryptInit(long, CKM, long)} instead
      */
+    @Deprecated
     public static long DecryptInit(long session, CKM mechanism, long key) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_DecryptInit session=0x%08x key=0x%08x\n  %s", session, key, mechanism));
-        long rv =NATIVE.C_DecryptInit(session, mechanism, key);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_DecryptInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.DecryptInit(NATIVE, session, mechanism, key);
     }
 
     /**
@@ -685,20 +556,11 @@ public class C {
      * @param dataLen gets p-text size
      * @return {@link CKR} return code
      * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link Ci#Decrypt(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static long Decrypt(long session, byte[] encryptedData, byte[] data, LongRef dataLen) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_Decrypt session=0x%08x dataLen=%d\n encryptedData (len=%d):\n", session, dataLen.value(), encryptedData.length));
-            Hex.dump(sb, encryptedData, 0, encryptedData.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_Decrypt(session, encryptedData, baLen(encryptedData), data, dataLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_Decrypt rv=0x%08x{%s}\n  data (len=%d):\n", rv, CKR.L2S(rv), dataLen.value()));
-            Hex.dump(sb, data, 0, (int) dataLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.Decrypt(NATIVE, session, encryptedData, data, dataLen);
     }
 
     /**
@@ -709,20 +571,11 @@ public class C {
      * @param dataLen get p-text size
      * @return {@link CKR} return code
      * @see NativeProvider#C_DecryptUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link Ci#DecryptUpdate(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static long DecryptUpdate(long session, byte[] encryptedPart, byte[] data, LongRef dataLen) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_DecryptUpdate session=0x%08x dataLen=%d\n  encryptedPart (len=%d):\n", session, dataLen.value(), encryptedPart.length));
-            Hex.dump(sb, encryptedPart, 0, encryptedPart.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_DecryptUpdate(session, encryptedPart, baLen(encryptedPart), data, dataLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_DecryptUpdate rv=0x%08x{%s}\n  data (len=%d):\n", rv, CKR.L2S(rv), dataLen.value()));
-            Hex.dump(sb, data, 0, (int) dataLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.DecryptUpdate(NATIVE, session, encryptedPart, data, dataLen);
     }
 
     /**
@@ -732,16 +585,11 @@ public class C {
      * @param lastPartLen p-text size
      * @return {@link CKR} return code
      * @see NativeProvider#C_DecryptFinal(long, byte[], LongRef)
+     * @deprecated use {@link Ci#DecryptFinal(long, byte[], LongRef)} instead
      */
+    @Deprecated
     public static long DecryptFinal(long session, byte[] lastPart, LongRef lastPartLen) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_DecryptFinal session=0x%08x lastPartLen=%d", session, lastPartLen.value()));
-        long rv =NATIVE.C_DecryptFinal(session, lastPart, lastPartLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_DecryptFinal rv=0x%08x{%s}\n  lastPart (len=%d):\n", rv, CKR.L2S(rv), lastPartLen.value()));
-            Hex.dump(sb, lastPart, 0, (int) lastPartLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.DecryptFinal(NATIVE, session, lastPart, lastPartLen);
     }
 
     /**
@@ -750,12 +598,11 @@ public class C {
      * @param mechanism the digesting mechanism
      * @return {@link CKR} return code
      * @see NativeProvider#C_DigestInit(long, CKM)
+     * @deprecated use {@link Ci#DigestInit(long, CKM)} instead
      */
+    @Deprecated
     public static long DigestInit(long session, CKM mechanism) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_DigestInit session=0x%08x\n  %s", session, mechanism));
-        long rv =NATIVE.C_DigestInit(session, mechanism);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_DigestInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.DigestInit(NATIVE, session, mechanism);
     }
 
     /**
@@ -766,20 +613,11 @@ public class C {
      * @param digestLen gets digest length
      * @return {@link CKR} return code
      * @see NativeProvider#C_Digest(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link Ci#Digest(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static long Digest(long session, byte[] data, byte[] digest, LongRef digestLen) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_Digest session=0x%08x digestLen=%d\n  data (len=%d):\n", session, digestLen.value(), data.length));
-            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_Digest(session, data, baLen(data), digest, digestLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_Digest rv=0x%08x{%s}\n  digest (len=%d):\n", rv, CKR.L2S(rv), digestLen.value()));
-            Hex.dump(sb, digest, 0, (int) digestLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.Digest(NATIVE, session, data, digest, digestLen);
     }
 
     /**
@@ -788,16 +626,11 @@ public class C {
      * @param part data to be digested
      * @return {@link CKR} return code
      * @see NativeProvider#C_DigestUpdate(long, byte[], long)
+     * @deprecated use {@link Ci#DigestUpdate(long, byte[])} instead
      */
+    @Deprecated
     public static long DigestUpdate(long session, byte[] part) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_DigestUpdate session=0x%08x\n  part (len=%d):\n", session, part.length));
-            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_DigestUpdate(session, part, baLen(part));
-        if (log.isDebugEnabled()) log.debug(String.format("< C_DigestUpdate rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.DigestUpdate(NATIVE, session, part);
     }
 
     /**
@@ -807,12 +640,11 @@ public class C {
      * @param key secret key to digest
      * @return {@link CKR} return code
      * @see NativeProvider#C_DigestKey(long, long)
+     * @deprecated use {@link Ci#DigestKey(long, long)} instead
      */
+    @Deprecated
     public static long DigestKey(long session, long key) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_DigestKey session=0x%08x key=0x%08x", session, key));
-        long rv =NATIVE.C_DigestKey(session, key);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_DigestKey rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.DigestKey(NATIVE, session, key);
     }
 
     /**
@@ -822,16 +654,11 @@ public class C {
      * @param digestLen gets byte count of digest
      * @return {@link CKR} return code
      * @see NativeProvider#C_DigestFinal(long, byte[], LongRef)
+     * @deprecated use {@link Ci#DigestFinal(long, byte[], LongRef)} instead
      */
+    @Deprecated
     public static long DigestFinal(long session, byte[] digest, LongRef digestLen) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_DigestFial session=0x%08x digestLen=%d", session, digestLen.value()));
-        long rv =NATIVE.C_DigestFinal(session, digest, digestLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_DigestFinal rv=0x%08x{%s}\n  digest (len=%d):\n", rv, CKR.L2S(rv), digestLen.value()));
-            Hex.dump(sb, digest, 0, (int) digestLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.DigestFinal(NATIVE, session, digest, digestLen);
     }
 
     /**
@@ -843,12 +670,11 @@ public class C {
      * @param key handle of signature key
      * @return {@link CKR} return code
      * @see NativeProvider#C_SignInit(long, CKM, long)
+     * @deprecated use {@link Ci#SignInit(long, CKM, long)} instead
      */
+    @Deprecated
     public static long SignInit(long session, CKM mechanism, long key) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_SignInit session=0x%08x key=0x%08x\n  %s", session, key, mechanism));
-        long rv =NATIVE.C_SignInit(session, mechanism, key);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_SignInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.SignInit(NATIVE, session, mechanism, key);
     }
 
     /**
@@ -860,20 +686,11 @@ public class C {
      * @param signatureLen gets signature length
      * @return {@link CKR} return code
      * @see NativeProvider#C_Sign(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link Ci#Sign(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static long Sign(long session, byte[] data, byte[] signature, LongRef signatureLen) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_Sign session=0x%08x signatureLen=%d\n  data (len=%d):\n", session, signatureLen.value(), data.length));
-            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_Sign(session, data, baLen(data), signature, signatureLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_Sign rv=0x%08x{%s}\n  signature (len=%d):\n", rv, CKR.L2S(rv), signatureLen.value()));
-            Hex.dump(sb, signature, 0, (int) signatureLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.Sign(NATIVE, session, data, signature, signatureLen);
     }
 
     /**
@@ -884,16 +701,11 @@ public class C {
      * @param part data to sign
      * @return {@link CKR} return code
      * @see NativeProvider#C_SignUpdate(long, byte[], long)
+     * @deprecated use {@link Ci#SignUpdate(long, byte[])} instead
      */
+    @Deprecated
     public static long SignUpdate(long session, byte[] part) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_SignUpdate session=0x%08x\n  part (len=%d):\n", session, part.length));
-            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_SignUpdate(session, part, baLen(part));
-        if (log.isDebugEnabled()) log.debug(String.format("< C_SignUpdate rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.SignUpdate(NATIVE, session, part);
     }
 
     /**
@@ -903,16 +715,11 @@ public class C {
      * @param signatureLen gets signature length
      * @return {@link CKR} return code
      * @see NativeProvider#C_SignFinal(long, byte[], LongRef)
+     * @deprecated use {@link Ci#SignFinal(long, byte[], LongRef)} instead
      */
+    @Deprecated
     public static long SignFinal(long session, byte[] signature, LongRef signatureLen) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_SignFinal session=0x%08x signatureLen=%d", session, signatureLen.value()));
-        long rv =NATIVE.C_SignFinal(session, signature, signatureLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_SignFinal rv=0x%08x{%s}\n  signature (len=%d):\n", rv, CKR.L2S(rv), signatureLen.value()));
-            Hex.dump(sb, signature, 0, (int) signatureLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.SignFinal(NATIVE, session, signature, signatureLen);
     }
 
     /**
@@ -922,12 +729,11 @@ public class C {
      * @param key handle f the signature key
      * @return {@link CKR} return code
      * @see NativeProvider#C_SignRecoverInit(long, CKM, long)
+     * @deprecated use {@link Ci#SignRecoverInit(long, CKM, long)} instead
      */
+    @Deprecated
     public static long SignRecoverInit(long session, CKM mechanism, long key) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_SignRecoverInit session=0x%08x key=0x%08x\n  %s", session, key, mechanism));
-        long rv =NATIVE.C_SignRecoverInit(session, mechanism, key);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_SignRecoverInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.SignRecoverInit(NATIVE, session, mechanism, key);
     }
 
     /**
@@ -938,20 +744,11 @@ public class C {
      * @param signatureLen gets signature length
      * @return {@link CKR} return code
      * @see NativeProvider#C_SignRecover(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link Ci#SignRecover(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static long SignRecover(long session, byte[] data, byte[] signature, LongRef signatureLen) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_SignRecover session=0x%08x signatureLen=%d\n  data (len=%d):\n", session, signatureLen.value(), data.length));
-            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_SignRecover(session, data, baLen(data), signature, signatureLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_SignRecover rv=0x%08x{%s}\n  signature (len=%d):\n", rv, CKR.L2S(rv), signatureLen.value()));
-            Hex.dump(sb, signature, 0, (int) signatureLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.SignRecover(NATIVE, session, data, signature, signatureLen);
     }
 
     /**
@@ -962,12 +759,11 @@ public class C {
      * @param key verification key
      * @return {@link CKR} return code
      * @see NativeProvider#C_VerifyInit(long, CKM, long)
+     * @deprecated use {@link Ci#VerifyInit(long, CKM, long)} instead
      */
+    @Deprecated
     public static long VerifyInit(long session, CKM mechanism, long key) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_VerifyInit session=0x%08x key=0x%08x\n  %s", session, key, mechanism));
-        long rv =NATIVE.C_VerifyInit(session, mechanism, key);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_VerifyInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.VerifyInit(NATIVE, session, mechanism, key);
     }
 
     /**
@@ -978,18 +774,11 @@ public class C {
      * @param signature signature
      * @return {@link CKR} return code
      * @see NativeProvider#C_Verify(long, byte[], long, byte[], long)
+     * @deprecated use {@link Ci#Verify(long, byte[], byte[])} instead
      */
+    @Deprecated
     public static long Verify(long session, byte[] data, byte[] signature) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_Verify session=0x%08x\n  data (len=%d):\n", session, data.length));
-            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
-            sb.append("\n  signature (len=%d):\n");
-            Hex.dump(sb, signature, 0, signature.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_Verify(session, data, baLen(data), signature, baLen(signature));
-        log.debug(String.format("< C_Verify rv=0x%08x{%s} ", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.Verify(NATIVE, session, data, signature);
     }
 
     /**
@@ -999,16 +788,11 @@ public class C {
      * @param part signed data
      * @return {@link CKR} return code
      * @see NativeProvider#C_VerifyUpdate(long, byte[], long)
+     * @deprecated use {@link Ci#VerifyUpdate(long, byte[])} instead
      */
+    @Deprecated
     public static long VerifyUpdate(long session, byte[] part) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_VerifyUpdate session=0x%08x\n  part (len=%d):\n", session, part.length));
-            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_VerifyUpdate(session, part, baLen(part));
-        if (log.isDebugEnabled()) log.debug(String.format("< C_VerifyUpdate rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.VerifyUpdate(NATIVE, session, part);
     }
 
     /**
@@ -1017,16 +801,11 @@ public class C {
      * @param signature signature to verify
      * @return {@link CKR} return code
      * @see NativeProvider#C_VerifyFinal(long, byte[], long)
+     * @deprecated use {@link Ci#VerifyFinal(long, byte[])} instead
      */
+    @Deprecated
     public static long VerifyFinal(long session, byte[] signature) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_VerifyFinal session=0x%08x\n  signature (len=%d):\n", session, signature.length));
-            Hex.dump(sb, signature, 0, signature.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_VerifyFinal(session, signature, baLen(signature));
-        if (log.isDebugEnabled()) log.debug(String.format("< C_VerifyFinal rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.VerifyFinal(NATIVE, session, signature);
     }
 
     /**
@@ -1036,12 +815,11 @@ public class C {
      * @param key verification key
      * @return {@link CKR} return code
      * @see NativeProvider#C_VerifyRecoverInit(long, CKM, long)
+     * @deprecated use {@link Ci#VerifyRecoverInit(long, CKM, long)} instead
      */
+    @Deprecated
     public static long VerifyRecoverInit(long session, CKM mechanism, long key) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_VerifyRecoverInit session=0x%08x key=0x%08x\n  %s", session, key, mechanism));
-        long rv =NATIVE.C_VerifyRecoverInit(session, mechanism, key);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_VerifyRecoverInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.VerifyRecoverInit(NATIVE, session, mechanism, key);
     }
 
     /**
@@ -1052,20 +830,11 @@ public class C {
      * @param dataLen gets signed data length
      * @return {@link CKR} return code
      * @see NativeProvider#C_VerifyRecover(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link Ci#VerifyRecover(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static long VerifyRecover(long session, byte[] signature, byte[] data, LongRef dataLen) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_VerifyRecover session=0x%08x dataLen=%d\n  signature (len=%d):\n", session, dataLen.value(), signature.length));
-            Hex.dump(sb, signature, 0, signature.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_VerifyRecover(session, signature, baLen(signature), data, dataLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_VerifyRecover rv=0x%08x{%s}\n  data (len=%d):\n", rv, CKR.L2S(rv), dataLen.value()));
-            Hex.dump(sb, data, 0, (int) dataLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.VerifyRecover(NATIVE, session, signature, data, dataLen);
     }
 
     /**
@@ -1076,21 +845,11 @@ public class C {
      * @param encryptedPartLen get c-text length
      * @return {@link CKR} return code
      * @see NativeProvider#C_DigestEncryptUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link Ci#DigestEncryptUpdate(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static long DigestEncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_DigestEncryptUpdate session=0x%08x encryptedPartLen=%d\n  part (len=%d):\n", session, encryptedPartLen, part.length));
-            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_DigestEncryptUpdate(session, part, baLen(part),
-                encryptedPart, encryptedPartLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_DigestEncryptUpdate rv=0x%08x{%s}\n  encryptedPart (len=%d):\n", rv, CKR.L2S(rv), encryptedPartLen));
-            Hex.dump(sb, encryptedPart, 0, (int) encryptedPartLen.value, "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.DigestEncryptUpdate(NATIVE, session, part, encryptedPart, encryptedPartLen);
     }
 
     /**
@@ -1101,21 +860,11 @@ public class C {
      * @param partLen gets plaintext length
      * @return {@link CKR} return code
      * @see NativeProvider#C_DecryptDigestUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link Ci#DecryptDigestUpdate(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static long DecryptDigestUpdate(long session, byte[] encryptedPart, byte[] part, LongRef partLen) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_DecryptDigestUpdate session=0x%08x partLen=%d\n  encryptedPart (len=%d):\n", session, partLen.value(), encryptedPart.length));
-            Hex.dump(sb, encryptedPart, 0, encryptedPart.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_DecryptDigestUpdate(session,
-                encryptedPart, baLen(encryptedPart), part, partLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_DecryptDigestUpdate rv=0x%08x{%s}\n  part (len=%d):\n", rv, CKR.L2S(rv), partLen.value()));
-            Hex.dump(sb, part, 0, (int) partLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.DecryptDigestUpdate(NATIVE, session, encryptedPart, part, partLen);
     }
 
     /**
@@ -1126,21 +875,11 @@ public class C {
      * @param encryptedPartLen gets c-text length
      * @return {@link CKR} return code
      * @see NativeProvider#C_SignEncryptUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link Ci#SignEncryptUpdate(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static long SignEncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_SignEncryptUdate session=0x%08x encryptedPartLen=%d\n  part (len=%d):\n", session, encryptedPartLen.value(), part.length));
-            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_SignEncryptUpdate(session, part, baLen(part),
-                encryptedPart, encryptedPartLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_SignEncryptUpdate rv=0x%08x{%s}\n  encryptedPart (len=%d):\n", rv, CKR.L2S(rv), encryptedPartLen.value()));
-            Hex.dump(sb, encryptedPart, 0, (int) encryptedPartLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.SignEncryptUpdate(NATIVE, session, part, encryptedPart, encryptedPartLen);
     }
 
     /**
@@ -1151,21 +890,11 @@ public class C {
      * @param partLen gets p-text length
      * @return {@link CKR} return code
      * @see NativeProvider#C_DecryptVerifyUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link Ci#DecryptVerifyUpdate(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static long DecryptVerifyUpdate(long session, byte[] encryptedPart, byte[] part, LongRef partLen) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_DecryptVerifyUpdate session=0x%08x partLen=%d\n  encryptedPart (len=%d):\n", session, partLen.value(), encryptedPart.length));
-            Hex.dump(sb, encryptedPart, 0, encryptedPart.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_DecryptVerifyUpdate(session,
-                encryptedPart, baLen(encryptedPart), part, partLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_DecryptVerifyUpdate rv=0x%08x{%s}\n  part (len=%d):\n", rv, CKR.L2S(rv), partLen.value()));
-            Hex.dump(sb, part, 0, (int) partLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.DecryptVerifyUpdate(NATIVE, session, encryptedPart, part, partLen);
     }
 
     /**
@@ -1176,16 +905,11 @@ public class C {
      * @param key gets handle of new key
      * @return {@link CKR} return code
      * @see NativeProvider#C_GenerateKey(long, CKM, CKA[], long, LongRef)
+     * @deprecated use {@link Ci#GenerateKey(long, CKM, CKA[], LongRef)} instead
      */
+    @Deprecated
     public static long GenerateKey(long session, CKM mechanism, CKA[] templ, LongRef key) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_GenerateKey session=0x%08x %s\n", session, mechanism));
-            dumpTemplate(sb, templ);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_GenerateKey(session, mechanism, templ, templLen(templ), key);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_GenerateKey rv=0x%08x{%s} key=0x%08x", rv, CKR.L2S(rv), key.value()));
-        return rv;
+        return NC.GenerateKey(NATIVE, session, mechanism, templ, key);
     }
 
     /**
@@ -1198,28 +922,12 @@ public class C {
      * @param privateKey gets handle of new private key
      * @return {@link CKR} return code
      * @see NativeProvider#C_GenerateKeyPair(long, CKM, CKA[], long, CKA[], long, LongRef, LongRef)
+     * @deprecated use {@link Ci#GenerateKeyPair(long, CKM, CKA[], CKA[], LongRef, LongRef)} instead
      */
+    @Deprecated
     public static long GenerateKeyPair(long session, CKM mechanism, CKA[] publicKeyTemplate,
-            CKA[] privateKeyTemplate, LongRef publicKey, LongRef privateKey) {
-        if (publicKey == null) {
-            publicKey = new LongRef();
-        }
-        if (privateKey == null) {
-            privateKey = new LongRef();
-        }
-
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_GenerateKeyPair session=0x%08x\n  %s", session, mechanism));
-            sb.append("\n  publicKeyTemplate:\n");
-            dumpTemplate(sb, publicKeyTemplate);
-            sb.append("\n  privateKeyTemplate:\n");
-            dumpTemplate(sb, privateKeyTemplate);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_GenerateKeyPair(session, mechanism,
-                publicKeyTemplate, templLen(publicKeyTemplate), privateKeyTemplate, templLen(privateKeyTemplate), publicKey, privateKey);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_GenerateKeyPair rv=0x%08x{%s} publicKey=0x%08x privateKey=0x%08x", rv, CKR.L2S(rv), publicKey.value(), privateKey.value()));
-        return rv;
+                                       CKA[] privateKeyTemplate, LongRef publicKey, LongRef privateKey) {
+        return NC.GenerateKeyPair(NATIVE, session, mechanism, publicKeyTemplate, privateKeyTemplate, publicKey, privateKey);
     }
 
     /**
@@ -1232,19 +940,13 @@ public class C {
      * @param wrappedKeyLen gets wrapped key length
      * @return {@link CKR} return code
      * @see NativeProvider#C_WrapKey(long, CKM, long, long, byte[], LongRef)
+     * @deprecated use {@link Ci#WrapKey(long, CKM, long, long, byte[], LongRef)} instead
      */
+    @Deprecated
     public static long WrapKey(long session, CKM mechanism, long wrappingKey, long key,
-            byte[] wrappedKey, LongRef wrappedKeyLen) {
+                               byte[] wrappedKey, LongRef wrappedKeyLen) {
 
-        if (log.isDebugEnabled()) log.debug(String.format("> C_WrapKey session=0x%08x key=0x%08x\n  %s", session, key, mechanism));
-        long rv =NATIVE.C_WrapKey(session, mechanism, wrappingKey,
-                key, wrappedKey, wrappedKeyLen);
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_WrapKey rv=0x%08x{%s}\n  wrappedKey (len=%d):\n", rv, CKR.L2S(rv), wrappedKeyLen.value()));
-            Hex.dump(sb, wrappedKey, 0, (int) wrappedKeyLen.value(), "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.WrapKey(NATIVE, session, mechanism, wrappingKey, key, wrappedKey, wrappedKeyLen);
     }
 
     /**
@@ -1257,21 +959,12 @@ public class C {
      * @param key gets new handle
      * @return {@link CKR} return code
      * @see NativeProvider#C_UnwrapKey(long, CKM, long, byte[], long, CKA[], long, LongRef)
+     * @deprecated use {@link Ci#UnwrapKey(long, CKM, long, byte[], CKA[], LongRef)} instead
      */
+    @Deprecated
     public static long UnwrapKey(long session, CKM mechanism, long unwrappingKey, byte[] wrappedKey,
             CKA[] templ, LongRef key) {
-
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_UnwrapKey session=0x%08x unwrappingKey=0x%08x %s\n  wrappedKey (len=%d):\n", session, unwrappingKey, mechanism, wrappedKey.length));
-            Hex.dump(sb, wrappedKey, 0, wrappedKey.length, "  ", 32, false);
-            sb.append('\n');
-            dumpTemplate(sb, templ);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_UnwrapKey(session, mechanism, unwrappingKey,
-                wrappedKey, baLen(wrappedKey), templ, templLen(templ), key);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_UnwrapKey rv=0x%08x{%s} key=0x%08x", rv, CKR.L2S(rv), key.value()));
-        return rv;
+        return NC.UnwrapKey(NATIVE, session, mechanism, unwrappingKey, wrappedKey, templ, key);
     }
 
     /**
@@ -1283,16 +976,11 @@ public class C {
      * @param key ges new handle
      * @return {@link CKR} return code
      * @see NativeProvider#C_DeriveKey(long, CKM, long, CKA[], long, LongRef)
+     * @deprecated use {@link Ci#DeriveKey(long, CKM, long, CKA[], LongRef)} instead
      */
+    @Deprecated
     public static long DeriveKey(long session, CKM mechanism, long baseKey, CKA[] templ, LongRef key) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_DeriveKey session=0x%08x baseKey=0x%08x %s\n", session, baseKey, mechanism));
-            dumpTemplate(sb, templ);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_DeriveKey(session, mechanism, baseKey, templ, templLen(templ), key);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_DeriveKey rv=0x%08x{%s} key=0x%08x", rv, CKR.L2S(rv), key.value()));
-        return rv;
+        return NC.DeriveKey(NATIVE, session, mechanism, baseKey, templ, key);
     }
 
     /**
@@ -1301,16 +989,11 @@ public class C {
      * @param seed the seed material
      * @return {@link CKR} return code
      * @see NativeProvider#C_SeedRandom(long, byte[], long)
+     * @deprecated use {@link Ci#SeedRandom(long, byte[])} instead
      */
+    @Deprecated
     public static long SeedRandom(long session, byte[] seed) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("> C_SeedRandom session=0x%08x\n  seed (len=%d):\n", session, seed.length));
-            Hex.dump(sb, seed, 0, seed.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        long rv =NATIVE.C_SeedRandom(session, seed, baLen(seed));
-        if (log.isDebugEnabled()) log.debug(String.format("< C_SeedRandom rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.SeedRandom(NATIVE, session, seed);
     }
 
     /**
@@ -1319,16 +1002,11 @@ public class C {
      * @param randomData receives the random data
      * @return {@link CKR} return code
      * @see NativeProvider#C_GenerateRandom(long, byte[], long)
+     * @deprecated use {@link Ci#GenerateRandom(long, byte[])} instead
      */
+    @Deprecated
     public static long GenerateRandom(long session, byte[] randomData) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_GenerateRandom session=0x%08x randomLen=%d", session, randomData.length));
-        long rv =NATIVE.C_GenerateRandom(session, randomData, baLen(randomData));
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(String.format("< C_GenerateRandom rv=0x%08x{%s}\n  randomData (len=%d):\n", rv, CKR.L2S(rv), randomData.length));
-            Hex.dump(sb, randomData, 0, randomData.length, "  ", 32, false);
-            log.debug(sb);
-        }
-        return rv;
+        return NC.GenerateRandom(NATIVE, session, randomData);
     }
 
     /**
@@ -1338,12 +1016,11 @@ public class C {
      * @param session the session's handle
      * @return {@link CKR} return code
      * @see NativeProvider#C_GetFunctionStatus(long)
+     * @deprecated use {@link Ci#GetFunctionStatus(long)} instead
      */
+    @Deprecated
     public static long GetFunctionStatus(long session) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_GetFunctionStatus session=0x%08x", session));
-        long rv =NATIVE.C_GetFunctionStatus(session);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_GetFunctionStatus rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
+        return NC.GetFunctionStatus(NATIVE, session);
     }
 
     /**
@@ -1353,99 +1030,10 @@ public class C {
      * @param session the session's handle
      * @return {@link CKR} return code
      * @see NativeProvider#C_CancelFunction(long)
+     * @deprecated use {@link Ci#CancelFunction(long)} instead
      */
+    @Deprecated
     public static long CancelFunction(long session) {
-        if (log.isDebugEnabled()) log.debug(String.format("> C_CancelFunction session=0x%08x", session));
-        long rv =NATIVE.C_CancelFunction(session);
-        if (log.isDebugEnabled()) log.debug(String.format("< C_CancelFunction rv=0x%08x{%s}", rv, CKR.L2S(rv)));
-        return rv;
-    }
-
-    /**
-     * Return length of buf (0 if buf is null).
-     * @param buf buf
-     * @return length of buf (0 if buf is null)
-     */
-    private static int baLen(byte[] buf) {
-        return buf == null ? 0 : buf.length;
-    }
-
-    /**
-     * Return length of template (0 if template is null).
-     * @param templ template
-     * @return length of template (0 if template is null)
-     */
-    private static int templLen(CKA[] templ) {
-        return templ == null ? 0 : templ.length;
-    }
-
-    /**
-     * Dump for debug.
-     * @param sb write to
-     */
-    private static void dumpTemplate(StringBuilder sb, CKA[] template) {
-        int templateLen = templLen(template);
-        sb.append("  template (size=").append(templateLen).append(')');
-        for (int i = 0; i < templateLen; i++) {
-            sb.append("\n  ");
-            template[i].dump(sb);
-        }
-    }
-
-    /**
-     * Helper method.  Adds all public static final long fields in c to map, mapping field value to name.
-     * @param c class
-     * @return map of field value:name
-     */
-    public static Map<Long, String> createL2SMap(Class<?> c) {
-        Map<Long, String> map = new HashMap<Long, String>();
-        try {
-            for (Field f : c.getDeclaredFields()) {
-                // only put 'public static final long' in map
-                if (f.getType() == long.class && Modifier.isPublic(f.getModifiers())
-                        && Modifier.isStatic(f.getModifiers()) && Modifier.isFinal(f.getModifiers())) {
-                    map.put(f.getLong(null), f.getName());
-                }
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        return map;
-    }
-
-    /**
-     * Helper method, Maps l to constant name, or value 'unknown %s constant 0x08x' % (ckx, l)'.
-     * @param map L2S map
-     * @param ckx prefix of constant type, e.g. 'CKA'
-     * @param l constant value
-     * @return constant name, or value 'unknown %s constant 0x08x' % (ckx, l)'.
-     */
-    public static String l2s(Map<Long, String> map, String ckx, long l) {
-        String s = map.get(l);
-        if (s != null) {
-            return s;
-        } else {
-          return String.format("unknown %s constant 0x%08x", ckx, l);
-        }
-    }
-
-    /**
-     * Helper method.  String format of flags.
-     * @param l2s l2s map
-     * @param flags flags
-     * @return string format of flags
-     */
-    public static String f2s(Map<Long, String> l2s, long flags) {
-        StringBuilder sb = new StringBuilder();
-        String sep = "";
-        for (int i = 63; i >= 0; i--) {
-            long mask = 1L << i;
-            if ((flags & mask) != 0) {
-                sb.append(sep);
-                sb.append(C.l2s(l2s, "CKF", mask));
-                sep = "|";
-            }
-        }
-        return sb.toString();
+        return NC.CancelFunction(NATIVE, session);
     }
 }

--- a/src/main/java/org/pkcs11/jacknji11/C.java
+++ b/src/main/java/org/pkcs11/jacknji11/C.java
@@ -1036,4 +1036,40 @@ public class C {
     public static long CancelFunction(long session) {
         return NC.CancelFunction(NATIVE, session);
     }
+
+    /**
+     * Helper method.  Adds all public static final long fields in c to map, mapping field value to name.
+     * @param c class
+     * @return map of field value:name
+     * @deprecated use {@link NC#createL2SMap(Class)} instead
+     */
+    @Deprecated
+    public static Map<Long, String> createL2SMap(Class<?> c) {
+        return NC.createL2SMap(c);
+    }
+
+    /**
+     * Helper method, Maps l to constant name, or value 'unknown %s constant 0x08x' % (ckx, l)'.
+     * @param map L2S map
+     * @param ckx prefix of constant type, e.g. 'CKA'
+     * @param l constant value
+     * @return constant name, or value 'unknown %s constant 0x08x' % (ckx, l)'.
+     * @deprecated use {@link NC#l2s(Map, String, long)} instead
+     */
+    @Deprecated
+    public static String l2s(Map<Long, String> map, String ckx, long l) {
+        return NC.l2s(map, ckx, l);
+    }
+
+    /**
+     * Helper method.  String format of flags.
+     * @param l2s l2s map
+     * @param flags flags
+     * @return string format of flags
+     * @deprecated use {@link NC#f2s(Map, long)} instead
+     */
+    @Deprecated
+    public static String f2s(Map<Long, String> l2s, long flags) {
+        return NC.f2s(l2s, flags);
+    }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CE.java
+++ b/src/main/java/org/pkcs11/jacknji11/CE.java
@@ -21,6 +21,8 @@
 
 package org.pkcs11.jacknji11;
 
+import org.pkcs11.jacknji11.jna.JNA;
+
 /**
  * This is the preferred java interface for calling cryptoki functions.
  *
@@ -48,27 +50,34 @@ package org.pkcs11.jacknji11;
  * </ol>
  *
  * @author Joel Hockey (joel.hockey@gmail.com)
+ * @deprecated Use the {@link CEi} class instead
  */
+@Deprecated
 public class CE {
 
     /**
      * Initialize cryptoki.
      * @see C#Initialize()
      * @see NativeProvider#C_Initialize(CK_C_INITIALIZE_ARGS)
+     * @deprecated use {@link CEi#Initialize()} instead
      */
+    @Deprecated
     public static void Initialize() {
-        long rv = C.Initialize();
-        if (rv != CKR.OK) throw new CKRException(rv);
+        if (C.NATIVE == null) {
+            C.NATIVE = new JNA();
+        }
+        NCE.Initialize(C.NATIVE);
     }
 
     /**
      * Called to indicate that an application is finished with the Cryptoki library.
      * @see C#Finalize()
      * @see NativeProvider#C_Finalize(NativePointer)
+     * @deprecated use {@link CEi#Finalize()} instead
      */
+    @Deprecated
     public static void Finalize() {
-        long rv = C.Finalize();
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.Finalize(C.NATIVE);
     }
 
     /**
@@ -76,10 +85,11 @@ public class CE {
      * @param info location that receives information
      * @see C#GetInfo(CK_INFO)
      * @see NativeProvider#C_GetInfo(CK_INFO)
+     * @deprecated use {@link CEi#GetInfo(CK_INFO)} instead
      */
+    @Deprecated
     public static void GetInfo(CK_INFO info) {
-        long rv = C.GetInfo(info);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.GetInfo(C.NATIVE, info);
     }
 
     /**
@@ -87,11 +97,11 @@ public class CE {
      * @return info
      * @see C#GetInfo(CK_INFO)
      * @see NativeProvider#C_GetInfo(CK_INFO)
+     * @deprecated use {@link CEi#GetInfo()} instead
      */
+    @Deprecated
     public static CK_INFO GetInfo() {
-        CK_INFO info = new CK_INFO();
-        GetInfo(info);
-        return info;
+        return NCE.GetInfo(C.NATIVE);
     }
 
     /**
@@ -101,10 +111,11 @@ public class CE {
      * @param count receives the number of slots
      * @see C#GetSlotList(boolean, long[], LongRef)
      * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef)
+     * @deprecated use {@link CEi#GetSlotList(boolean, long[], LongRef)} instead
      */
+    @Deprecated
     public static void GetSlotList(boolean tokenPresent, long[] slotList, LongRef count) {
-        long rv = C.GetSlotList(tokenPresent, slotList, count);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.GetSlotList(C.NATIVE, tokenPresent, slotList, count);
     }
 
     /**
@@ -113,13 +124,11 @@ public class CE {
      * @return slot list
      * @see C#GetSlotList(boolean, long[], LongRef)
      * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef)
+     * @deprecated use {@link CEi#GetSlotList(boolean)} instead
      */
+    @Deprecated
     public static long[] GetSlotList(boolean tokenPresent) {
-        LongRef count = new LongRef();
-        GetSlotList(tokenPresent, null, count);
-        long[] result = new long[(int) count.value()];
-        GetSlotList(tokenPresent, result, count);
-        return result;
+        return NCE.GetSlotList(C.NATIVE, tokenPresent);
     }
 
     /**
@@ -130,16 +139,11 @@ public class CE {
      * @see C#GetTokenInfo(long, CK_TOKEN_INFO)
      * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef)
      * @see NativeProvider#C_GetTokenInfo(long, CK_TOKEN_INFO)
+     * @deprecated use {@link CEi#GetSlot(String)} instead
      */
+    @Deprecated
     public static long GetSlot(String label) {
-        long[] allslots = GetSlotList(true);
-        for (long slot : allslots) {
-            CK_TOKEN_INFO tok = GetTokenInfo(slot);
-            if (tok != null && tok.label != null && new String(tok.label).trim().equals(label)) {
-                return slot;
-            }
-        }
-        throw new CKRException("No slot found with label [" + label + "]", CKR.SLOT_ID_INVALID);
+        return NCE.GetSlot(C.NATIVE, label);
     }
 
     /**
@@ -148,10 +152,11 @@ public class CE {
      * @param info receives the slot information
      * @see C#GetSlotInfo(long, CK_SLOT_INFO)
      * @see NativeProvider#C_GetSlotInfo(long, CK_SLOT_INFO)
+     * @deprecated use {@link CEi#GetSlotInfo(long, CK_SLOT_INFO)} instead
      */
+    @Deprecated
     public static void GetSlotInfo(long slotID, CK_SLOT_INFO info) {
-        long rv = C.GetSlotInfo(slotID, info);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.GetSlotInfo(C.NATIVE, slotID, info);
     }
 
     /**
@@ -160,11 +165,11 @@ public class CE {
      * @return slot info
      * @see C#GetSlotInfo(long, CK_SLOT_INFO)
      * @see NativeProvider#C_GetSlotInfo(long, CK_SLOT_INFO)
+     * @deprecated use {@link CEi#GetSlotInfo(long)} instead
      */
+    @Deprecated
     public static CK_SLOT_INFO GetSlotInfo(long slotID) {
-        CK_SLOT_INFO info = new CK_SLOT_INFO();
-        GetSlotInfo(slotID, info);
-        return info;
+        return NCE.GetSlotInfo(C.NATIVE, slotID);
     }
 
     /**
@@ -173,10 +178,11 @@ public class CE {
      * @param info receives the token information
      * @see C#GetTokenInfo(long, CK_TOKEN_INFO)
      * @see NativeProvider#C_GetTokenInfo(long, CK_TOKEN_INFO)
+     * @deprecated use {@link CEi#GetTokenInfo(long, CK_TOKEN_INFO)} instead
      */
+    @Deprecated
     public static void GetTokenInfo(long slotID, CK_TOKEN_INFO info) {
-        long rv = C.GetTokenInfo(slotID, info);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.GetTokenInfo(C.NATIVE, slotID, info);
     }
 
     /**
@@ -185,11 +191,11 @@ public class CE {
      * @return token info
      * @see C#GetTokenInfo(long, CK_TOKEN_INFO)
      * @see NativeProvider#C_GetTokenInfo(long, CK_TOKEN_INFO)
+     * @deprecated use {@link CEi#GetTokenInfo(long)} instead
      */
+    @Deprecated
     public static CK_TOKEN_INFO GetTokenInfo(long slotID) {
-        CK_TOKEN_INFO info = new CK_TOKEN_INFO();
-        GetTokenInfo(slotID, info);
-        return info;
+        return NCE.GetTokenInfo(C.NATIVE, slotID);
     }
 
     /**
@@ -199,10 +205,11 @@ public class CE {
      * @param pReserved reserved.  Should be null
      * @see C#WaitForSlotEvent(long, LongRef, NativePointer)
      * @see NativeProvider#C_WaitForSlotEvent(long, LongRef, NativePointer)
+     * @deprecated use {@link CEi#WaitForSlotEvent(long, LongRef, NativePointer)} instead
      */
+    @Deprecated
     public static void WaitForSlotEvent(long flags, LongRef slot, NativePointer pReserved) {
-        long rv = C.WaitForSlotEvent(flags, slot, pReserved);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.WaitForSlotEvent(C.NATIVE, flags, slot, pReserved);
     }
 
     /**
@@ -212,10 +219,11 @@ public class CE {
      * @param count gets # of mechanisms
      * @see C#GetMechanismList(long, long[], LongRef)
      * @see NativeProvider#C_GetMechanismList(long, long[], LongRef)
+     * @deprecated use {@link CEi#GetMechanismList(long, long[], LongRef)} instead
      */
+    @Deprecated
     public static void GetMechanismList(long slotID, long[] mechanismList, LongRef count) {
-        long rv = C.GetMechanismList(slotID, mechanismList, count);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.GetMechanismList(C.NATIVE, slotID, mechanismList, count);
     }
 
     /**
@@ -224,13 +232,11 @@ public class CE {
      * @return mechanism list (array of {@link CKM})
      * @see C#GetMechanismList(long, long[], LongRef)
      * @see NativeProvider#C_GetMechanismList(long, long[], LongRef)
+     * @deprecated use {@link CEi#GetMechanismList(long)} instead
      */
+    @Deprecated
     public static long[] GetMechanismList(long slotID) {
-        LongRef count = new LongRef();
-        GetMechanismList(slotID, null, count);
-        long[] mechanisms = new long[(int) count.value()];
-        GetMechanismList(slotID, mechanisms, count);
-        return mechanisms;
+        return NCE.GetMechanismList(C.NATIVE, slotID);
     }
 
     /**
@@ -240,10 +246,11 @@ public class CE {
      * @param info receives mechanism info
      * @see C#GetMechanismInfo(long, long, CK_MECHANISM_INFO)
      * @see NativeProvider#C_GetMechanismInfo(long, long, CK_MECHANISM_INFO)
+     * @deprecated use {@link CEi#GetMechanismInfo(long, long, CK_MECHANISM_INFO)} instead
      */
+    @Deprecated
     public static void GetMechanismInfo(long slotID, long type, CK_MECHANISM_INFO info) {
-        long rv = C.GetMechanismInfo(slotID, type, info);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.GetMechanismInfo(C.NATIVE, slotID, type, info);
     }
 
     /**
@@ -252,11 +259,11 @@ public class CE {
      * @return mechanism info
      * @see C#GetMechanismInfo(long, long, CK_MECHANISM_INFO)
      * @see NativeProvider#C_GetMechanismInfo(long, long, CK_MECHANISM_INFO)
+     * @deprecated use {@link CEi#GetMechanismInfo(long, long)} instead
      */
+    @Deprecated
     public static CK_MECHANISM_INFO GetMechanismInfo(long slotID, long type) {
-        CK_MECHANISM_INFO info = new CK_MECHANISM_INFO();
-        GetMechanismInfo(slotID, type, info);
-        return info;
+        return NCE.GetMechanismInfo(C.NATIVE, slotID, type);
     }
 
     /**
@@ -267,10 +274,11 @@ public class CE {
      * it will be padded or truncated as required
      * @see C#InitToken(long, byte[], byte[])
      * @see NativeProvider#C_InitToken(long, byte[], long, byte[])
+     * @deprecated use {@link CEi#InitToken(long, byte[], byte[])} instead
      */
+    @Deprecated
     public static void InitToken(long slotID, byte[] pin, byte[] label) {
-        long rv = C.InitToken(slotID, pin, label);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.InitToken(C.NATIVE, slotID, pin, label);
     }
 
     /**
@@ -279,10 +287,11 @@ public class CE {
      * @param pin the normal user's PIN
      * @see C#InitPIN(long, byte[])
      * @see NativeProvider#C_InitPIN(long, byte[], long)
+     * @deprecated use {@link CEi#InitPIN(long, byte[])} instead
      */
+    @Deprecated
     public static void InitPIN(long session, byte[] pin) {
-        long rv = C.InitPIN(session, pin);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.InitPIN(C.NATIVE, session, pin);
     }
 
     /**
@@ -292,10 +301,11 @@ public class CE {
      * @param newPin new PIN
      * @see C#SetPIN(long, byte[], byte[])
      * @see NativeProvider#C_SetPIN(long, byte[], long, byte[], long)
+     * @deprecated use {@link CEi#SetPIN(long, byte[], byte[])} instead
      */
+    @Deprecated
     public static void SetPIN(long session, byte[] oldPin, byte[] newPin) {
-        long rv = C.SetPIN(session, oldPin, newPin);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.SetPIN(C.NATIVE, session, oldPin, newPin);
     }
 
     /**
@@ -307,10 +317,11 @@ public class CE {
      * @param session gets session handle
      * @see C#OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
      * @see NativeProvider#C_OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
+     * @deprecated use {@link CEi#OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)} instead
      */
+    @Deprecated
     public static void OpenSession(long slotID, long flags, NativePointer application, CK_NOTIFY notify, LongRef session) {
-        long rv = C.OpenSession(slotID, flags, application, notify, session);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.OpenSession(C.NATIVE, slotID, flags, application, notify, session);
     }
 
     /**
@@ -322,11 +333,11 @@ public class CE {
      * @return session handle
      * @see C#OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
      * @see NativeProvider#C_OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
+     * @deprecated use {@link CEi#OpenSession(long, long, NativePointer, CK_NOTIFY)} instead
      */
+    @Deprecated
     public static long OpenSession(long slotID, long flags, NativePointer application, CK_NOTIFY notify) {
-        LongRef session = new LongRef();
-        OpenSession(slotID, flags, application, notify, session);
-        return session.value();
+        return NCE.OpenSession(C.NATIVE, slotID, flags, application, notify);
     }
 
     /**
@@ -336,9 +347,11 @@ public class CE {
      * @return session handle
      * @see C#OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
      * @see NativeProvider#C_OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
+     * @deprecated use {@link CEi#OpenSession(long)} instead
      */
+    @Deprecated
     public static long OpenSession(long slotID) {
-        return OpenSession(slotID, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        return NCE.OpenSession(C.NATIVE, slotID);
     }
 
     /**
@@ -346,10 +359,11 @@ public class CE {
      * @param session the session's handle
      * @see C#CloseSession(long)
      * @see NativeProvider#C_CloseSession(long)
+     * @deprecated use {@link CEi#CloseSession(long)} instead
      */
+    @Deprecated
     public static void CloseSession(long session) {
-        long rv = C.CloseSession(session);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.CloseSession(C.NATIVE, session);
     }
 
     /**
@@ -357,10 +371,11 @@ public class CE {
      * @param slotID the token's slot
      * @see C#CloseAllSessions(long)
      * @see NativeProvider#C_CloseAllSessions(long)
+     * @deprecated use {@link CEi#CloseAllSessions(long)} instead
      */
+    @Deprecated
     public static void CloseAllSessions(long slotID) {
-        long rv = C.CloseAllSessions(slotID);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.CloseAllSessions(C.NATIVE, slotID);
     }
 
     /**
@@ -369,10 +384,11 @@ public class CE {
      * @param info receives session info
      * @see C#GetSessionInfo(long, CK_SESSION_INFO)
      * @see NativeProvider#C_GetSessionInfo(long, CK_SESSION_INFO)
+     * @deprecated use {@link CEi#GetSessionInfo(long, CK_SESSION_INFO)} instead
      */
+    @Deprecated
     public static void GetSessionInfo(long session, CK_SESSION_INFO info) {
-        long rv = C.GetSessionInfo(session, info);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.GetSessionInfo(C.NATIVE, session, info);
     }
 
     /**
@@ -381,11 +397,11 @@ public class CE {
      * @return session info
      * @see C#GetSessionInfo(long, CK_SESSION_INFO)
      * @see NativeProvider#C_GetSessionInfo(long, CK_SESSION_INFO)
+     * @deprecated use {@link CEi#GetSessionInfo(long)} instead
      */
+    @Deprecated
     public static CK_SESSION_INFO GetSessionInfo(long session) {
-        CK_SESSION_INFO info = new CK_SESSION_INFO();
-        GetSessionInfo(session, info);
-        return info;
+        return NCE.GetSessionInfo(C.NATIVE, session);
     }
 
     /**
@@ -395,10 +411,11 @@ public class CE {
      * @param operationStateLen gets state length
      * @see C#GetOperationState(long, byte[], LongRef)
      * @see NativeProvider#C_GetOperationState(long, byte[], LongRef)
+     * @deprecated use {@link CEi#GetObjectSize(long, long, LongRef)} instead
      */
+    @Deprecated
     public static void GetOperationState(long session, byte[] operationState, LongRef operationStateLen) {
-        long rv = C.GetOperationState(session, operationState, operationStateLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.GetOperationState(C.NATIVE, session, operationState, operationStateLen);
     }
 
     /**
@@ -407,13 +424,11 @@ public class CE {
      * @return operation state
      * @see C#GetOperationState(long, byte[], LongRef)
      * @see NativeProvider#C_GetOperationState(long, byte[], LongRef)
+     * @deprecated use {@link CEi#GetOperationState(long)} instead
      */
+    @Deprecated
     public static byte[] GetOperationState(long session) {
-        LongRef len = new LongRef();
-        GetOperationState(session, null, len);
-        byte[] result = new byte[(int) len.value()];
-        GetOperationState(session, result, len);
-        return resize(result, (int) len.value());
+        return NCE.GetOperationState(C.NATIVE, session);
     }
 
     /**
@@ -424,10 +439,11 @@ public class CE {
      * @param authenticationKey sign/verify key
      * @see C#SetOperationState(long, byte[], long, long)
      * @see NativeProvider#C_SetOperationState(long, byte[], long, long, long)
+     * @deprecated use {@link CEi#SetOperationState(long, byte[], long, long)} instead
      */
+    @Deprecated
     public static void SetOperationState(long session, byte[] operationState, long encryptionKey, long authenticationKey) {
-        long rv = C.SetOperationState(session, operationState, encryptionKey, authenticationKey);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.SetOperationState(C.NATIVE, session, operationState, encryptionKey, authenticationKey);
     }
 
     /**
@@ -437,10 +453,11 @@ public class CE {
      * @param pin the user's PIN
      * @see C#Login(long, long, byte[])
      * @see NativeProvider#C_Login(long, long, byte[], long)
+     * @deprecated use {@link CEi#Login(long, long, byte[])} instead
      */
+    @Deprecated
     public static void Login(long session, long userType, byte[] pin) {
-        long rv = C.Login(session, userType, pin);
-        if (rv != CKR.OK && rv != CKR.USER_ALREADY_LOGGED_IN) throw new CKRException(rv);
+        NCE.Login(C.NATIVE, session, userType, pin);
     }
 
     /**
@@ -449,9 +466,11 @@ public class CE {
      * @param pin the normal user's PIN
      * @see C#Login(long, long, byte[])
      * @see NativeProvider#C_Login(long, long, byte[], long)
+     * @deprecated use {@link CEi#LoginUser(long, byte[])} instead
      */
+    @Deprecated
     public static void LoginUser(long session, byte[] pin) {
-        Login(session, CKU.USER, pin);
+        NCE.LoginUser(C.NATIVE, session, pin);
     }
 
     /**
@@ -460,9 +479,11 @@ public class CE {
      * @param pin the normal user's PIN encoded in a single byte encoding format such as ISO8859-1
      * @see C#Login(long, long, byte[])
      * @see NativeProvider#C_Login(long, long, byte[], long)
+     * @deprecated use {@link CEi#LoginUser(long, String)} instead
      */
+    @Deprecated
     public static void LoginUser(long session, String pin) {
-        LoginUser(session, Buf.c2b(pin));
+        NCE.LoginUser(C.NATIVE, session, pin);
     }
 
     /**
@@ -471,9 +492,11 @@ public class CE {
      * @param pin SO PIN
      * @see C#Login(long, long, byte[])
      * @see NativeProvider#C_Login(long, long, byte[], long)
+     * @deprecated use {@link CEi#LoginSO(long, byte[])} instead
      */
+    @Deprecated
     public static void LoginSO(long session, byte[] pin) {
-        Login(session, CKU.SO, pin);
+        NCE.LoginSO(C.NATIVE, session, pin);
     }
 
     /**
@@ -482,9 +505,11 @@ public class CE {
      * @param pin SO PIN encoded in a single byte encoding format such as ISO8859-1
      * @see C#Login(long, long, byte[])
      * @see NativeProvider#C_Login(long, long, byte[], long)
+     * @deprecated use {@link CEi#LoginSO(long, String)} instead
      */
+    @Deprecated
     public static void LoginSO(long session, String pin) {
-        LoginSO(session, Buf.c2b(pin));
+        NCE.LoginSO(C.NATIVE, session, pin);
     }
 
     /**
@@ -492,10 +517,11 @@ public class CE {
      * @param session the session's handle
      * @see C#Logout(long)
      * @see NativeProvider#C_Logout(long)
+     * @deprecated use {@link CEi#Logout(long)} instead
      */
+    @Deprecated
     public static void Logout(long session) {
-        long rv = C.Logout(session);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.Logout(C.NATIVE, session);
     }
 
     /**
@@ -505,10 +531,11 @@ public class CE {
      * @param object gets new object's handle
      * @see C#CreateObject(long, CKA[], LongRef)
      * @see NativeProvider#C_CreateObject(long, CKA[], long, LongRef)
+     * @deprecated use {@link CEi#CreateObject(long, CKA[], LongRef)} instead
      */
+    @Deprecated
     public static void CreateObject(long session, CKA[] templ, LongRef object) {
-        long rv = C.CreateObject(session, templ, object);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.CreateObject(C.NATIVE, session, templ, object);
     }
 
     /**
@@ -517,11 +544,11 @@ public class CE {
      * @return new object handle
      * @see C#CreateObject(long, CKA[], LongRef)
      * @see NativeProvider#C_CreateObject(long, CKA[], long, LongRef)
+     * @deprecated use {@link CEi#CreateObject(long, CKA...)} instead
      */
+    @Deprecated
     public static long CreateObject(long session, CKA... templ) {
-        LongRef object = new LongRef();
-        CreateObject(session, templ, object);
-        return object.value();
+        return NCE.CreateObject(C.NATIVE, session, templ);
     }
 
     /**
@@ -532,10 +559,11 @@ public class CE {
      * @param newObject receives handle of copy
      * @see C#CopyObject(long, long, CKA[], LongRef)
      * @see NativeProvider#C_CopyObject(long, long, CKA[], long, LongRef)
+     * @deprecated use {@link CEi#CopyObject(long, long, CKA[], LongRef)} instead
      */
+    @Deprecated
     public static void CopyObject(long session, long object, CKA[] templ, LongRef newObject) {
-        long rv = C.CopyObject(session, object, templ, newObject);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.CopyObject(C.NATIVE, session, object, templ, newObject);
     }
 
     /**
@@ -546,11 +574,11 @@ public class CE {
      * @return new object handle
      * @see C#CopyObject(long, long, CKA[], LongRef)
      * @see NativeProvider#C_CopyObject(long, long, CKA[], long, LongRef)
+     * @deprecated use {@link CEi#CopyObject(long, long, CKA...)} instead
      */
+    @Deprecated
     public static long CopyObject(long session, long object, CKA... templ) {
-        LongRef newObject = new LongRef();
-        CopyObject(session, object, templ, newObject);
-        return newObject.value();
+        return NCE.CopyObject(C.NATIVE, session, object, templ);
     }
 
     /**
@@ -559,10 +587,11 @@ public class CE {
      * @param object the object's handle
      * @see C#DestroyObject(long, long)
      * @see NativeProvider#C_DestroyObject(long, long)
+     * @deprecated use {@link CEi#DestroyObject(long, long)} instead
      */
+    @Deprecated
     public static void DestroyObject(long session, long object) {
-        long rv = C.DestroyObject(session, object);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.DestroyObject(C.NATIVE, session, object);
     }
 
     /**
@@ -572,10 +601,11 @@ public class CE {
      * @param size receives the size of object
      * @see C#GetObjectSize(long, long, LongRef)
      * @see NativeProvider#C_GetObjectSize(long, long, LongRef)
+     * @deprecated use {@link CEi#GetObjectSize(long, long, LongRef)} instead
      */
+    @Deprecated
     public static void GetObjectSize(long session, long object, LongRef size) {
-        long rv = C.GetObjectSize(session, object, size);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.GetObjectSize(C.NATIVE, session, object, size);
     }
 
     /**
@@ -585,11 +615,11 @@ public class CE {
      * @return size of object in bytes
      * @see C#GetObjectSize(long, long, LongRef)
      * @see NativeProvider#C_GetObjectSize(long, long, LongRef)
+     * @deprecated use {@link CEi#GetObjectSize(long, long)} instead
      */
+    @Deprecated
     public static long GetObjectSize(long session, long object) {
-        LongRef size = new LongRef();
-        GetObjectSize(session, object, size);
-        return size.value();
+        return NCE.GetObjectSize(C.NATIVE, session, object);
     }
 
     /**
@@ -599,13 +629,11 @@ public class CE {
      * @param templ specifies attributes, gets values
      * @see C#GetAttributeValue(long, long, CKA[])
      * @see NativeProvider#C_GetAttributeValue(long, long, CKA[], long)
+     * @deprecated use {@link CEi#GetAttributeValue(long, long, CKA...)} instead
      */
+    @Deprecated
     public static void GetAttributeValue(long session, long object, CKA... templ) {
-        if (templ == null || templ.length == 0) {
-            return;
-        }
-        long rv = C.GetAttributeValue(session, object, templ);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.GetAttributeValue(C.NATIVE, session, object, templ);
     }
 
     /**
@@ -615,20 +643,11 @@ public class CE {
      * @param cka {@link CKA} type
      * @see C#GetAttributeValue(long, long, CKA[])
      * @see NativeProvider#C_GetAttributeValue(long, long, CKA[], long)
+     * @deprecated use {@link CEi#GetAttributeValue(long, long, long)} instead
      */
+    @Deprecated
     public static CKA GetAttributeValue(long session, long object, long cka) {
-        CKA[] templ = {new CKA(cka)};
-        long rv = C.GetAttributeValue(session, object, templ);
-        if (rv == CKR.ATTRIBUTE_TYPE_INVALID || templ[0].ulValueLen == 0) {
-            return templ[0];
-        }
-        if (rv != CKR.OK) throw new CKRException(rv);
-
-        // allocate memory and call again
-        templ[0].pValue = new byte[(int) templ[0].ulValueLen];
-        rv = C.GetAttributeValue(session, object, templ);
-        if (rv != CKR.OK) throw new CKRException(rv);
-        return templ[0];
+        return NCE.GetAttributeValue(C.NATIVE, session, object, cka);
     }
 
     /**
@@ -640,38 +659,11 @@ public class CE {
      * @return attribute values
      * @see C#GetAttributeValue(long, long, CKA[])
      * @see NativeProvider#C_GetAttributeValue(long, long, CKA[], long)
+     * @deprecated use {@link CEi#GetAttributeValue(long, long, long...)} instead
      */
+    @Deprecated
     public static CKA[] GetAttributeValue(long session, long object, long... types) {
-        if (types == null || types.length == 0) {
-            return new CKA[0];
-        }
-        CKA[] templ = new CKA[types.length];
-        for (int i = 0; i < types.length; i++) {
-            templ[i] = new CKA(types[i], null);
-        }
-
-        // try getting all at once
-        try {
-            GetAttributeValue(session, object, templ);
-            // allocate memory and go again
-            for (CKA att : templ) {
-                att.pValue = att.ulValueLen > 0 ? new byte[(int) att.ulValueLen] : null;
-            }
-            GetAttributeValue(session, object, templ);
-            return templ;
-        } catch (CKRException ckre) {
-            // if we got CKR_ATTRIBUTE_TYPE_INVALID, then handle below
-            if (ckre.getCKR() != CKR.ATTRIBUTE_TYPE_INVALID) {
-                throw ckre;
-            }
-        }
-
-        // send gets one at a time
-        CKA[] result = new CKA[types.length];
-        for (int i = 0; i < types.length; i++) {
-            result[i] = GetAttributeValue(session, object, types[i]);
-        }
-        return result;
+        return NCE.GetAttributeValue(C.NATIVE, session, object, types);
     }
 
     /**
@@ -681,22 +673,24 @@ public class CE {
      * @param templ specifies attributes and values
      * @see C#SetAttributeValue(long, long, CKA[])
      * @see NativeProvider#C_SetAttributeValue(long, long, CKA[], long)
+     * @deprecated use {@link CEi#SetAttributeValue(long, long, CKA...)} instead
      */
+    @Deprecated
     public static void SetAttributeValue(long session, long object, CKA... templ) {
-        long rv = C.SetAttributeValue(session, object, templ);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.SetAttributeValue(C.NATIVE, session, object, templ);
     }
 
     /**
-     * Initailses a search for token and session objects that match a template.
+     * Initialises a search for token and session objects that match a template.
      * @param session the session's handle
      * @param templ attribute values to match
      * @see C#FindObjectsInit(long, CKA[])
      * @see NativeProvider#C_FindObjectsInit(long, CKA[], long)
+     * @deprecated use {@link CEi#FindObjectsInit(long, CKA...)} instead
      */
+    @Deprecated
     public static void FindObjectsInit(long session, CKA... templ) {
-        long rv = C.FindObjectsInit(session, templ);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.FindObjectsInit(C.NATIVE, session, templ);
     }
 
     /**
@@ -707,10 +701,11 @@ public class CE {
      * @param objectCount number of object handles returned
      * @see C#FindObjects(long, long[], LongRef)
      * @see NativeProvider#C_FindObjects(long, long[], long, LongRef)
+     * @deprecated use {@link CEi#FindObjects(long, long[], LongRef)} instead
      */
+    @Deprecated
     public static void FindObjects(long session, long[] found, LongRef objectCount) {
-        long rv = C.FindObjects(session, found, objectCount);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.FindObjects(C.NATIVE, session, found, objectCount);
     }
 
     /**
@@ -721,19 +716,11 @@ public class CE {
      * @return list of object handles
      * @see C#FindObjects(long, long[], LongRef)
      * @see NativeProvider#C_FindObjects(long, long[], long, LongRef)
+     * @deprecated use {@link CEi#FindObjects(long, int)} instead
      */
+    @Deprecated
     public static long[] FindObjects(long session, int maxObjects) {
-        long[] found = new long[maxObjects];
-        LongRef len = new LongRef();
-        FindObjects(session, found, len);
-        long count = len.value();
-        if (count == maxObjects) {
-            return found;
-        } else {
-            long[] result = new long[(int) count];
-            System.arraycopy(found, 0, result, 0, result.length);
-            return result;
-        }
+        return NCE.FindObjects(C.NATIVE, session, maxObjects);
     }
 
     /**
@@ -741,10 +728,11 @@ public class CE {
      * @param session the session's handle
      * @see C#FindObjectsFinal(long)
      * @see NativeProvider#C_FindObjectsFinal(long)
+     * @deprecated use {@link CEi#FindObjectsFinal(long)} instead
      */
+    @Deprecated
     public static void FindObjectsFinal(long session) {
-        long rv = C.FindObjectsFinal(session);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.FindObjectsFinal(C.NATIVE, session);
     }
 
     /**
@@ -754,31 +742,11 @@ public class CE {
      * @return all objects matching
      * @see C#FindObjectsInit(long, CKA[])
      * @see NativeProvider#C_FindObjectsInit(long, CKA[], long)
+     * @deprecated use {@link CEi#FindObjects(long, CKA...)} instead
      */
+    @Deprecated
     public static long[] FindObjects(long session, CKA... templ) {
-        FindObjectsInit(session, templ);
-        int maxObjects = 1024;
-        // call once
-        long[] result = FindObjects(session, maxObjects);
-        // most likely we are done now
-        if (result.length < maxObjects) {
-            FindObjectsFinal(session);
-            return result;
-        }
-
-        // this is a lot of objects!
-        while (true) {
-            maxObjects *= 2;
-            long[] found = FindObjects(session, maxObjects);
-            long[] temp = new long[result.length + found.length];
-            System.arraycopy(result, 0, temp, 0, result.length);
-            System.arraycopy(found, 0, temp, result.length, found.length);
-            result = temp;
-            if (found.length < maxObjects) { // exhausted
-                FindObjectsFinal(session);
-                return result;
-            }
-        }
+        return NCE.FindObjects(C.NATIVE, session, templ);
     }
 
     /**
@@ -788,10 +756,11 @@ public class CE {
      * @param key handle of encryption key
      * @see C#EncryptInit(long, CKM, long)
      * @see NativeProvider#C_EncryptInit(long, CKM, long)
+     * @deprecated use {@link CEi#EncryptInit(long, CKM, long)} instead
      */
+    @Deprecated
     public static void EncryptInit(long session, CKM mechanism, long key) {
-        long rv = C.EncryptInit(session, mechanism, key);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.EncryptInit(C.NATIVE, session, mechanism, key);
     }
 
     /**
@@ -802,10 +771,11 @@ public class CE {
      * @param encryptedDataLen gets c-text size
      * @see C#Encrypt(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#Encrypt(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static void Encrypt(long session, byte[] data, byte[] encryptedData, LongRef encryptedDataLen) {
-        long rv = C.Encrypt(session, data, encryptedData, encryptedDataLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.Encrypt(C.NATIVE, session, data, encryptedData, encryptedDataLen);
     }
 
     /**
@@ -816,13 +786,11 @@ public class CE {
      * @return encrypted data
      * @see C#Encrypt(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#EncryptPad(long, byte[])} instead
      */
+    @Deprecated
     public static byte[] EncryptPad(long session, byte[] data) {
-        LongRef l = new LongRef();
-        Encrypt(session, data, null, l);
-        byte[] result = new byte[(int) l.value()];
-        Encrypt(session, data, result, l);
-        return resize(result, (int) l.value());
+        return NCE.EncryptPad(C.NATIVE, session, data);
     }
 
     /**
@@ -833,12 +801,11 @@ public class CE {
      * @return encrypted data
      * @see C#Encrypt(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#Encrypt(long, byte[])} instead
      */
+    @Deprecated
     public static byte[] Encrypt(long session, byte[] data) {
-        byte[] result = new byte[data.length];
-        LongRef l = new LongRef(result.length);
-        Encrypt(session, data, result, l);
-        return resize(result, (int) l.value);
+        return NCE.Encrypt(C.NATIVE, session, data);
     }
 
     /**
@@ -849,10 +816,11 @@ public class CE {
      * @param encryptedPartLen gets c-text size
      * @see C#EncryptUpdate(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_EncryptUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#EncryptUpdate(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static void EncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
-        long rv = C.EncryptUpdate(session, part, encryptedPart, encryptedPartLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.EncryptUpdate(C.NATIVE, session, part, encryptedPart, encryptedPartLen);
     }
 
     /**
@@ -862,13 +830,11 @@ public class CE {
      * @return encrypted part
      * @see C#EncryptUpdate(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_EncryptUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#EncryptUpdate(long, byte[])} instead
      */
+    @Deprecated
     public static byte[] EncryptUpdate(long session, byte[] part) {
-        LongRef l = new LongRef();
-        EncryptUpdate(session, part, null, l);
-        byte[] result = new byte[(int) l.value()];
-        EncryptUpdate(session, part, result, l);
-        return resize(result, (int) l.value());
+        return NCE.EncryptUpdate(C.NATIVE, session, part);
     }
 
     /**
@@ -878,10 +844,11 @@ public class CE {
      * @param lastEncryptedPartLen gets last size
      * @see C#EncryptFinal(long, byte[], LongRef)
      * @see NativeProvider#C_EncryptFinal(long, byte[], LongRef)
+     * @deprecated use {@link CEi#EncryptFinal(long, byte[], LongRef)} instead
      */
+    @Deprecated
     public static void EncryptFinal(long session, byte[] lastEncryptedPart, LongRef lastEncryptedPartLen) {
-        long rv = C.EncryptFinal(session, lastEncryptedPart, lastEncryptedPartLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.EncryptFinal(C.NATIVE, session, lastEncryptedPart, lastEncryptedPartLen);
     }
 
     /**
@@ -890,13 +857,11 @@ public class CE {
      * @return last encrypted part
      * @see C#EncryptFinal(long, byte[], LongRef)
      * @see NativeProvider#C_EncryptFinal(long, byte[], LongRef)
+     * @deprecated use {@link CEi#EncryptFinal(long)} instead
      */
+    @Deprecated
     public static byte[] EncryptFinal(long session) {
-        LongRef l = new LongRef();
-        EncryptFinal(session, null, l);
-        byte[] result = new byte[(int) l.value()];
-        EncryptFinal(session, result, l);
-        return resize(result, (int) l.value());
+        return NCE.EncryptFinal(C.NATIVE, session);
     }
 
     /**
@@ -909,10 +874,11 @@ public class CE {
      * @return encrypted data
      * @see C#Encrypt(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#EncryptPad(long, CKM, long, byte[])} instead
      */
+    @Deprecated
     public static byte[] EncryptPad(long session, CKM mechanism, long key, byte[] data) {
-        EncryptInit(session, mechanism, key);
-        return EncryptPad(session, data);
+        return NCE.EncryptPad(C.NATIVE, session, mechanism, key, data);
     }
 
     /**
@@ -925,10 +891,11 @@ public class CE {
      * @return encrypted data
      * @see C#Encrypt(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#Encrypt(long, CKM, long, byte[])} instead
      */
+    @Deprecated
     public static byte[] Encrypt(long session, CKM mechanism, long key, byte[] data) {
-        EncryptInit(session, mechanism, key);
-        return Encrypt(session, data);
+        return NCE.Encrypt(C.NATIVE, session, mechanism, key, data);
     }
 
     /**
@@ -938,10 +905,11 @@ public class CE {
      * @param key handle of decryption key
      * @see C#DecryptInit(long, CKM, long)
      * @see NativeProvider#C_DecryptInit(long, CKM, long)
+     * @deprecated use {@link CEi#DecryptInit(long, CKM, long)} instead
      */
+    @Deprecated
     public static void DecryptInit(long session, CKM mechanism, long key) {
-        long rv = C.DecryptInit(session, mechanism, key);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.DecryptInit(C.NATIVE, session, mechanism, key);
     }
 
     /**
@@ -952,11 +920,11 @@ public class CE {
      * @param dataLen gets p-text size
      * @see C#Decrypt(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#Decrypt(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static void Decrypt(long session, byte[] encryptedData, byte[] data, LongRef dataLen) {
-        long rv = C.Decrypt(session, encryptedData, data, dataLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
-
+        NCE.Decrypt(C.NATIVE, session, encryptedData, data, dataLen);
     }
 
     /**
@@ -967,13 +935,11 @@ public class CE {
      * @return plaintext
      * @see C#Decrypt(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#DecryptPad(long, byte[])} instead
      */
+    @Deprecated
     public static byte[] DecryptPad(long session, byte[] encryptedData) {
-        LongRef l = new LongRef();
-        Decrypt(session, encryptedData, null, l);
-        byte[] result = new byte[(int) l.value()];
-        Decrypt(session, encryptedData, result, l);
-        return resize(result, (int) l.value());
+        return NCE.DecryptPad(C.NATIVE, session, encryptedData);
     }
 
     /**
@@ -984,12 +950,11 @@ public class CE {
      * @return plaintext
      * @see C#Decrypt(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#Decrypt(long, byte[])} instead
      */
+    @Deprecated
     public static byte[] Decrypt(long session, byte[] encryptedData) {
-        byte[] result = new byte[encryptedData.length];
-        LongRef l = new LongRef(result.length);
-        Decrypt(session, encryptedData, result, l);
-        return resize(result, (int) l.value());
+        return NCE.Decrypt(C.NATIVE, session, encryptedData);
     }
 
     /**
@@ -1000,10 +965,11 @@ public class CE {
      * @param dataLen get p-text size
      * @see C#DecryptUpdate(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_DecryptUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#DecryptUpdate(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static void DecryptUpdate(long session, byte[] encryptedPart, byte[] data, LongRef dataLen) {
-        long rv = C.DecryptUpdate(session, encryptedPart, data, dataLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.DecryptUpdate(C.NATIVE, session, encryptedPart, data, dataLen);
     }
 
     /**
@@ -1013,13 +979,11 @@ public class CE {
      * @return plaintext
      * @see C#DecryptUpdate(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_DecryptUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#DecryptUpdate(long, byte[])} instead
      */
+    @Deprecated
     public static byte[] DecryptUpdate(long session, byte[] encryptedPart) {
-        LongRef l = new LongRef();
-        DecryptUpdate(session, encryptedPart, null, l);
-        byte[] result = new byte[(int) l.value()];
-        DecryptUpdate(session, encryptedPart, result, l);
-        return resize(result, (int) l.value());
+        return NCE.DecryptUpdate(C.NATIVE, session, encryptedPart);
     }
 
     /**
@@ -1029,10 +993,11 @@ public class CE {
      * @param lastPartLen p-text size
      * @see C#DecryptFinal(long, byte[], LongRef)
      * @see NativeProvider#C_DecryptFinal(long, byte[], LongRef)
+     * @deprecated use {@link CEi#DigestFinal(long, byte[], LongRef)} instead
      */
+    @Deprecated
     public static void DecryptFinal(long session, byte[] lastPart, LongRef lastPartLen) {
-        long rv = C.DecryptFinal(session, lastPart, lastPartLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.DecryptFinal(C.NATIVE, session, lastPart, lastPartLen);
     }
 
     /**
@@ -1041,13 +1006,11 @@ public class CE {
      * @return last part of plaintext
      * @see C#DecryptFinal(long, byte[], LongRef)
      * @see NativeProvider#C_DecryptFinal(long, byte[], LongRef)
+     * @deprecated use {@link CEi#DigestFinal(long)} instead
      */
+    @Deprecated
     public static byte[] DecryptFinal(long session) {
-        LongRef l = new LongRef();
-        DecryptFinal(session, null, l);
-        byte[] result = new byte[(int) l.value()];
-        DecryptFinal(session, result, l);
-        return resize(result, (int) l.value());
+        return NCE.DecryptFinal(C.NATIVE, session);
     }
 
     /**
@@ -1060,10 +1023,11 @@ public class CE {
      * @return plaintext
      * @see C#Decrypt(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#DecryptPad(long, CKM, long, byte[])} instead
      */
+    @Deprecated
     public static byte[] DecryptPad(long session, CKM mechanism, long key, byte[] encryptedData) {
-        DecryptInit(session, mechanism, key);
-        return DecryptPad(session, encryptedData);
+        return NCE.DecryptPad(C.NATIVE, session, mechanism, key, encryptedData);
     }
 
     /**
@@ -1076,10 +1040,11 @@ public class CE {
      * @return plaintext
      * @see C#Decrypt(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#Decrypt(long, CKM, long, byte[])} instead
      */
+    @Deprecated
     public static byte[] Decrypt(long session, CKM mechanism, long key, byte[] encryptedData) {
-        DecryptInit(session, mechanism, key);
-        return Decrypt(session, encryptedData);
+        return NCE.Decrypt(C.NATIVE, session, mechanism, key, encryptedData);
     }
 
     /**
@@ -1088,10 +1053,11 @@ public class CE {
      * @param mechanism the digesting mechanism
      * @see C#DigestInit(long, CKM)
      * @see NativeProvider#C_DigestInit(long, CKM)
+     * @deprecated use {@link CEi#DigestInit(long, CKM)} instead
      */
+    @Deprecated
     public static void DigestInit(long session, CKM mechanism) {
-        long rv = C.DigestInit(session, mechanism);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.DigestInit(C.NATIVE, session, mechanism);
     }
 
     /**
@@ -1102,10 +1068,11 @@ public class CE {
      * @param digestLen gets digest length
      * @see C#Digest(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Digest(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#Digest(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static void Digest(long session, byte[] data, byte[] digest, LongRef digestLen) {
-        long rv = C.Digest(session, data, digest, digestLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.Digest(C.NATIVE, session, data, digest, digestLen);
     }
 
     /**
@@ -1115,13 +1082,11 @@ public class CE {
      * @return digest
      * @see C#Digest(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Digest(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#Digest(long, byte[])} instead
      */
+    @Deprecated
     public static byte[] Digest(long session, byte[] data) {
-        LongRef l = new LongRef();
-        Digest(session, data, null, l);
-        byte[] result = new byte[(int) l.value()];
-        Digest(session, data, result, l);
-        return resize(result, (int) l.value());
+        return NCE.Digest(C.NATIVE, session, data);
     }
 
     /**
@@ -1130,10 +1095,11 @@ public class CE {
      * @param part data to be digested
      * @see C#DigestUpdate(long, byte[])
      * @see NativeProvider#C_DigestUpdate(long, byte[], long)
+     * @deprecated use {@link CEi#DigestUpdate(long, byte[])} instead
      */
+    @Deprecated
     public static void DigestUpdate(long session, byte[] part) {
-        long rv = C.DigestUpdate(session, part);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.DigestUpdate(C.NATIVE, session, part);
     }
 
     /**
@@ -1143,10 +1109,11 @@ public class CE {
      * @param key secret key to digest
      * @see C#DigestKey(long, long)
      * @see NativeProvider#C_DigestKey(long, long)
+     * @deprecated use {@link CEi#DigestKey(long, long)} instead
      */
+    @Deprecated
     public static void DigestKey(long session, long key) {
-        long rv = C.DigestKey(session, key);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.DigestKey(C.NATIVE, session, key);
     }
 
     /**
@@ -1156,10 +1123,11 @@ public class CE {
      * @param digestLen gets byte count of digest
      * @see C#DigestFinal(long, byte[], LongRef)
      * @see NativeProvider#C_DigestFinal(long, byte[], LongRef)
+     * @deprecated use {@link CEi#DigestFinal(long, byte[], LongRef)} instead
      */
+    @Deprecated
     public static void DigestFinal(long session, byte[] digest, LongRef digestLen) {
-        long rv = C.DigestFinal(session, digest, digestLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.DigestFinal(C.NATIVE, session, digest, digestLen);
     }
 
     /**
@@ -1168,13 +1136,11 @@ public class CE {
      * @return digest
      * @see C#DigestFinal(long, byte[], LongRef)
      * @see NativeProvider#C_DigestFinal(long, byte[], LongRef)
+     * @deprecated use {@link CEi#DigestFinal(long)} instead
      */
+    @Deprecated
     public static byte[] DigestFinal(long session) {
-        LongRef l = new LongRef();
-        DigestFinal(session, null, l);
-        byte[] result = new byte[(int) l.value()];
-        DigestFinal(session, result, l);
-        return resize(result, (int) l.value());
+        return NCE.DigestFinal(C.NATIVE, session);
     }
 
     /**
@@ -1185,10 +1151,11 @@ public class CE {
      * @return digest
      * @see C#Digest(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Digest(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#Digest(long, CKM, byte[])} instead
      */
+    @Deprecated
     public static byte[] Digest(long session, CKM mechanism, byte[] data) {
-        DigestInit(session, mechanism);
-        return Digest(session, data);
+        return NCE.Digest(C.NATIVE, session, mechanism, data);
     }
 
     /**
@@ -1200,10 +1167,11 @@ public class CE {
      * @param key handle of signature key
      * @see C#SignInit(long, CKM, long)
      * @see NativeProvider#C_SignInit(long, CKM, long)
+     * @deprecated use {@link CEi#SignInit(long, CKM, long)} instead
      */
+    @Deprecated
     public static void SignInit(long session, CKM mechanism, long key) {
-        long rv = C.SignInit(session, mechanism, key);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.SignInit(C.NATIVE, session, mechanism, key);
     }
 
     /**
@@ -1215,10 +1183,11 @@ public class CE {
      * @param signatureLen gets signature length
      * @see C#Sign(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Sign(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#Sign(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static void Sign(long session, byte[] data, byte[] signature, LongRef signatureLen) {
-        long rv = C.Sign(session, data, signature, signatureLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.Sign(C.NATIVE, session, data, signature, signatureLen);
     }
 
     /**
@@ -1229,13 +1198,11 @@ public class CE {
      * @return signature
      * @see C#Sign(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Sign(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#Sign(long, byte[])} instead
      */
+    @Deprecated
     public static byte[] Sign(long session, byte[] data) {
-        LongRef l = new LongRef();
-        Sign(session, data, null, l);
-        byte[] result = new byte[(int) l.value()];
-        Sign(session, data, result, l);
-        return resize(result, (int) l.value());
+        return NCE.Sign(C.NATIVE, session, data);
     }
 
     /**
@@ -1246,10 +1213,11 @@ public class CE {
      * @param part data to sign
      * @see C#SignUpdate(long, byte[])
      * @see NativeProvider#C_SignUpdate(long, byte[], long)
+     * @deprecated use {@link CEi#SignUpdate(long, byte[])} instead
      */
+    @Deprecated
     public static void SignUpdate(long session, byte[] part) {
-        long rv = C.SignUpdate(session, part);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.SignUpdate(C.NATIVE, session, part);
     }
 
     /**
@@ -1259,10 +1227,11 @@ public class CE {
      * @param signatureLen gets signature length
      * @see C#SignFinal(long, byte[], LongRef)
      * @see NativeProvider#C_SignFinal(long, byte[], LongRef)
+     * @deprecated use {@link CEi#SignFinal(long, byte[], LongRef)} instead
      */
+    @Deprecated
     public static void SignFinal(long session, byte[] signature, LongRef signatureLen) {
-        long rv = C.SignFinal(session, signature, signatureLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.SignFinal(C.NATIVE, session, signature, signatureLen);
     }
 
     /**
@@ -1271,13 +1240,11 @@ public class CE {
      * @return signature
      * @see C#SignFinal(long, byte[], LongRef)
      * @see NativeProvider#C_SignFinal(long, byte[], LongRef)
+     * @deprecated use {@link CEi#SignFinal(long)} instead
      */
+    @Deprecated
     public static byte[] SignFinal(long session) {
-        LongRef l = new LongRef();
-        SignFinal(session, null, l);
-        byte[] result = new byte[(int) l.value()];
-        SignFinal(session, result, l);
-        return resize(result, (int) l.value());
+        return NCE.SignFinal(C.NATIVE, session);
     }
 
     /**
@@ -1290,10 +1257,11 @@ public class CE {
      * @return signature
      * @see C#Sign(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_Sign(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#Sign(long, CKM, long, byte[])} instead
      */
+    @Deprecated
     public static byte[] Sign(long session, CKM mechanism, long key, byte[] data) {
-        SignInit(session, mechanism, key);
-        return Sign(session, data);
+        return NCE.Sign(C.NATIVE, session, mechanism, key, data);
     }
 
     /**
@@ -1303,10 +1271,11 @@ public class CE {
      * @param key handle f the signature key
      * @see C#SignRecoverInit(long, CKM, long)
      * @see NativeProvider#C_SignRecoverInit(long, CKM, long)
+     * @deprecated use {@link CEi#SignRecoverInit(long, CKM, long)} instead
      */
+    @Deprecated
     public static void SignRecoverInit(long session, CKM mechanism, long key) {
-        long rv = C.SignRecoverInit(session, mechanism, key);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.SignRecoverInit(C.NATIVE, session, mechanism, key);
     }
 
     /**
@@ -1317,10 +1286,11 @@ public class CE {
      * @param signatureLen gets signature length
      * @see C#SignRecover(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_SignRecover(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#SignRecover(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static void SignRecover(long session, byte[] data, byte[] signature, LongRef signatureLen) {
-        long rv = C.SignRecover(session, data, signature, signatureLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.SignRecover(C.NATIVE, session, data, signature, signatureLen);
     }
 
     /**
@@ -1330,13 +1300,11 @@ public class CE {
      * @return signature
      * @see C#SignRecover(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_SignRecover(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#SignRecover(long, byte[])} instead
      */
+    @Deprecated
     public static byte[] SignRecover(long session, byte[] data) {
-        LongRef l = new LongRef();
-        SignRecover(session, data, null, l);
-        byte[] result = new byte[(int) l.value()];
-        SignRecover(session, data, result, l);
-        return resize(result, (int) l.value());
+        return NCE.SignRecover(C.NATIVE, session, data);
     }
 
     /**
@@ -1348,10 +1316,11 @@ public class CE {
      * @return signature
      * @see C#SignRecover(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_SignRecover(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#SignRecover(long, CKM, long, byte[])} instead
      */
+    @Deprecated
     public static byte[] SignRecover(long session, CKM mechanism, long key, byte[] data) {
-        SignRecoverInit(session, mechanism, key);
-        return SignRecover(session, data);
+        return NCE.SignRecover(C.NATIVE, session, mechanism, key, data);
     }
 
     /**
@@ -1362,10 +1331,11 @@ public class CE {
      * @param key verification key
      * @see C#VerifyInit(long, CKM, long)
      * @see NativeProvider#C_VerifyInit(long, CKM, long)
+     * @deprecated use {@link CEi#VerifyInit(long, CKM, long)} instead
      */
+    @Deprecated
     public static void VerifyInit(long session, CKM mechanism, long key) {
-        long rv = C.VerifyInit(session, mechanism, key);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.VerifyInit(C.NATIVE, session, mechanism, key);
     }
 
     /**
@@ -1376,10 +1346,11 @@ public class CE {
      * @param signature signature
      * @see C#Verify(long, byte[], byte[])
      * @see NativeProvider#C_Verify(long, byte[], long, byte[], long)
+     * @deprecated use {@link CEi#Verify(long, byte[], byte[])} instead
      */
+    @Deprecated
     public static void Verify(long session, byte[] data, byte[] signature) {
-        long rv = C.Verify(session, data, signature);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.Verify(C.NATIVE, session, data, signature);
     }
 
     /**
@@ -1389,10 +1360,11 @@ public class CE {
      * @param part signed data
      * @see C#VerifyUpdate(long, byte[])
      * @see NativeProvider#C_VerifyUpdate(long, byte[], long)
+     * @deprecated use {@link CEi#VerifyUpdate(long, byte[])} instead
      */
+    @Deprecated
     public static void VerifyUpdate(long session, byte[] part) {
-        long rv = C.VerifyUpdate(session, part);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.VerifyUpdate(C.NATIVE, session, part);
     }
 
     /**
@@ -1401,10 +1373,11 @@ public class CE {
      * @param signature signature to verify
      * @see C#VerifyFinal(long, byte[])
      * @see NativeProvider#C_VerifyFinal(long, byte[], long)
+     * @deprecated use {@link CEi#VerifyFinal(long, byte[])} instead
      */
+    @Deprecated
     public static void VerifyFinal(long session, byte[] signature) {
-        long rv = C.VerifyFinal(session, signature);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.VerifyFinal(C.NATIVE, session, signature);
     }
 
     /**
@@ -1417,10 +1390,11 @@ public class CE {
      * @param signature signature
      * @see C#Verify(long, byte[], byte[])
      * @see NativeProvider#C_Verify(long, byte[], long, byte[], long)
+     * @deprecated use {@link CEi#Verify(long, CKM, long, byte[], byte[])} instead
      */
+    @Deprecated
     public static void Verify(long session, CKM mechanism, long key, byte[] data, byte[] signature) {
-        VerifyInit(session, mechanism, key);
-        Verify(session, data, signature);
+        NCE.Verify(C.NATIVE, session, mechanism, key, data, signature);
     }
 
     /**
@@ -1430,10 +1404,11 @@ public class CE {
      * @param key verification key
      * @see C#VerifyRecoverInit(long, CKM, long)
      * @see NativeProvider#C_VerifyRecoverInit(long, CKM, long)
+     * @deprecated use {@link CEi#VerifyRecoverInit(long, CKM, long)} instead
      */
+    @Deprecated
     public static void VerifyRecoverInit(long session, CKM mechanism, long key) {
-        long rv = C.VerifyRecoverInit(session, mechanism, key);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.VerifyRecoverInit(C.NATIVE, session, mechanism, key);
     }
 
     /**
@@ -1444,10 +1419,11 @@ public class CE {
      * @param dataLen gets signed data length
      * @see C#VerifyRecover(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_VerifyRecover(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#VerifyRecover(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static void VerifyRecover(long session, byte[] signature, byte[] data, LongRef dataLen) {
-        long rv = C.VerifyRecover(session, signature, data, dataLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.VerifyRecover(C.NATIVE, session, signature, data, dataLen);
     }
 
     /**
@@ -1457,13 +1433,11 @@ public class CE {
      * @return data
      * @see C#VerifyRecover(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_VerifyRecover(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#VerifyRecover(long, byte[])} instead
      */
+    @Deprecated
     public static byte[] VerifyRecover(long session, byte[] signature) {
-        LongRef l = new LongRef();
-        VerifyRecover(session, signature, null, l);
-        byte[] result = new byte[(int) l.value()];
-        VerifyRecover(session, signature, result, l);
-        return resize(result, (int) l.value());
+        return NCE.VerifyRecover(C.NATIVE, session, signature);
     }
 
     /**
@@ -1475,10 +1449,11 @@ public class CE {
      * @return data
      * @see C#VerifyRecover(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_VerifyRecover(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#VerifyRecover(long, CKM, long, byte[])} instead
      */
+    @Deprecated
     public static byte[] VerifyRecover(long session, CKM mechanism, long key, byte[] signature) {
-        VerifyRecoverInit(session, mechanism, key);
-        return VerifyRecover(session, signature);
+        return NCE.VerifyRecover(C.NATIVE, session, mechanism, key, signature);
     }
 
     /**
@@ -1489,10 +1464,11 @@ public class CE {
      * @param encryptedPartLen get c-text length
      * @see C#DigestEncryptUpdate(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_DigestEncryptUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#DigestEncryptUpdate(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static void DigestEncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
-        long rv = C.DigestEncryptUpdate(session, part, encryptedPart, encryptedPartLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.DigestEncryptUpdate(C.NATIVE, session, part, encryptedPart, encryptedPartLen);
     }
 
     /**
@@ -1502,13 +1478,11 @@ public class CE {
      * @return encrypted part
      * @see C#DigestEncryptUpdate(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_DigestEncryptUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#DigestEncryptUpdate(long, byte[])} instead
      */
+    @Deprecated
     public static byte[] DigestEncryptUpdate(long session, byte[] part) {
-        LongRef l = new LongRef();
-        DigestEncryptUpdate(session, part, null, l);
-        byte[] result = new byte[(int) l.value()];
-        DigestEncryptUpdate(session, part, result, l);
-        return resize(result, (int) l.value());
+        return NCE.DigestEncryptUpdate(C.NATIVE, session, part);
     }
 
     /**
@@ -1519,10 +1493,11 @@ public class CE {
      * @param partLen gets plaintext length
      * @see C#DigestUpdate(long, byte[])
      * @see NativeProvider#C_DigestUpdate(long, byte[], long)
+     * @deprecated use {@link CEi#DecryptDigestUpdate(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static void DecryptDigestUpdate(long session, byte[] encryptedPart, byte[] part, LongRef partLen) {
-        long rv = C.DecryptDigestUpdate(session, encryptedPart, part, partLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.DecryptDigestUpdate(C.NATIVE, session, encryptedPart, part, partLen);
     }
 
     /**
@@ -1532,13 +1507,11 @@ public class CE {
      * @return plaintext
      * @see C#DecryptDigestUpdate(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_DecryptDigestUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#DecryptDigestUpdate(long, byte[])} instead
      */
+    @Deprecated
     public static byte[] DecryptDigestUpdate(long session, byte[] encryptedPart) {
-        LongRef l = new LongRef();
-        DecryptDigestUpdate(session, encryptedPart, null, l);
-        byte[] result = new byte[(int) l.value()];
-        DecryptDigestUpdate(session, encryptedPart, result, l);
-        return resize(result, (int) l.value());
+        return NCE.DecryptDigestUpdate(C.NATIVE, session, encryptedPart);
     }
 
     /**
@@ -1549,10 +1522,11 @@ public class CE {
      * @param encryptedPartLen gets c-text length
      * @see C#SignEncryptUpdate(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_SignEncryptUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#SignEncryptUpdate(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static void SignEncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
-        long rv = C.SignEncryptUpdate(session, part, encryptedPart, encryptedPartLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.SignEncryptUpdate(C.NATIVE, session, part, encryptedPart, encryptedPartLen);
     }
 
     /**
@@ -1562,13 +1536,11 @@ public class CE {
      * @return encrypted part
      * @see C#SignEncryptUpdate(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_SignEncryptUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#SignEncryptUpdate(long, byte[])} instead
      */
+    @Deprecated
     public static byte[] SignEncryptUpdate(long session, byte[] part) {
-        LongRef l = new LongRef();
-        SignEncryptUpdate(session, part, null, l);
-        byte[] result = new byte[(int) l.value()];
-        SignEncryptUpdate(session, part, result, l);
-        return resize(result, (int) l.value());
+        return NCE.SignEncryptUpdate(C.NATIVE, session, part);
     }
 
     /**
@@ -1579,10 +1551,11 @@ public class CE {
      * @param partLen gets p-text length
      * @see C#DecryptVerifyUpdate(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_DecryptVerifyUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#DecryptVerifyUpdate(long, byte[], byte[], LongRef)} instead
      */
+    @Deprecated
     public static void DecryptVerifyUpdate(long session, byte[] encryptedPart, byte[] part, LongRef partLen) {
-        long rv = C.DecryptVerifyUpdate(session, encryptedPart, part, partLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.DecryptVerifyUpdate(C.NATIVE, session, encryptedPart, part, partLen);
     }
 
     /**
@@ -1592,13 +1565,11 @@ public class CE {
      * @return plaintext
      * @see C#DecryptVerifyUpdate(long, byte[], byte[], LongRef)
      * @see NativeProvider#C_DecryptVerifyUpdate(long, byte[], long, byte[], LongRef)
+     * @deprecated use {@link CEi#DecryptVerifyUpdate(long, byte[])} instead
      */
+    @Deprecated
     public static byte[] DecryptVerifyUpdate(long session, byte[] encryptedPart) {
-        LongRef l = new LongRef();
-        DecryptVerifyUpdate(session, encryptedPart, null, l);
-        byte[] result = new byte[(int) l.value()];
-        DecryptVerifyUpdate(session, encryptedPart, result, l);
-        return resize(result, (int) l.value());
+        return NCE.DecryptVerifyUpdate(C.NATIVE, session, encryptedPart);
     }
 
     /**
@@ -1609,10 +1580,11 @@ public class CE {
      * @param key gets handle of new key
      * @see C#GenerateKey(long, CKM, CKA[], LongRef)
      * @see NativeProvider#C_GenerateKey(long, CKM, CKA[], long, LongRef)
+     * @deprecated use {@link CEi#GenerateKey(long, CKM, CKA[], LongRef)} instead
      */
+    @Deprecated
     public static void GenerateKey(long session, CKM mechanism, CKA[] templ, LongRef key) {
-        long rv = C.GenerateKey(session, mechanism, templ, key);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.GenerateKey(C.NATIVE, session, mechanism, templ, key);
     }
 
     /**
@@ -1623,11 +1595,11 @@ public class CE {
      * @return key handle
      * @see C#GenerateKey(long, CKM, CKA[], LongRef)
      * @see NativeProvider#C_GenerateKey(long, CKM, CKA[], long, LongRef)
+     * @deprecated use {@link CEi#GenerateKey(long, CKM, CKA...)} instead
      */
+    @Deprecated
     public static long GenerateKey(long session, CKM mechanism, CKA... templ) {
-        LongRef key = new LongRef();
-        GenerateKey(session, mechanism, templ, key);
-        return key.value();
+        return NCE.GenerateKey(C.NATIVE, session, mechanism, templ);
     }
 
     /**
@@ -1640,11 +1612,12 @@ public class CE {
      * @param privateKey gets handle of new private key
      * @see C#GenerateKeyPair(long, CKM, CKA[], CKA[], LongRef, LongRef)
      * @see NativeProvider#C_GenerateKeyPair(long, CKM, CKA[], long, CKA[], long, LongRef, LongRef)
+     * @deprecated use {@link CEi#GenerateKeyPair(long, CKM, CKA[], CKA[], LongRef, LongRef)} instead
      */
+    @Deprecated
     public static void GenerateKeyPair(long session, CKM mechanism, CKA[] publicKeyTemplate, CKA[] privateKeyTemplate,
-            LongRef publicKey, LongRef privateKey) {
-        long rv = C.GenerateKeyPair(session, mechanism, publicKeyTemplate, privateKeyTemplate, publicKey, privateKey);
-        if (rv != CKR.OK) throw new CKRException(rv);
+                                       LongRef publicKey, LongRef privateKey) {
+        NCE.GenerateKeyPair(C.NATIVE, session, mechanism, publicKeyTemplate, privateKeyTemplate, publicKey, privateKey);
     }
 
     /**
@@ -1657,10 +1630,11 @@ public class CE {
      * @param wrappedKeyLen gets wrapped key length
      * @see C#WrapKey(long, CKM, long, long, byte[], LongRef)
      * @see NativeProvider#C_WrapKey(long, CKM, long, long, byte[], LongRef)
+     * @deprecated use {@link CEi#WrapKey(long, CKM, long, long, byte[], LongRef)} instead
      */
+    @Deprecated
     public static void WrapKey(long session, CKM mechanism, long wrappingKey, long key, byte[] wrappedKey, LongRef wrappedKeyLen) {
-        long rv = C.WrapKey(session, mechanism, wrappingKey, key, wrappedKey, wrappedKeyLen);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.WrapKey(C.NATIVE, session, mechanism, wrappingKey, key, wrappedKey, wrappedKeyLen);
     }
 
     /**
@@ -1672,13 +1646,11 @@ public class CE {
      * @return wrapped key
      * @see C#WrapKey(long, CKM, long, long, byte[], LongRef)
      * @see NativeProvider#C_WrapKey(long, CKM, long, long, byte[], LongRef)
+     * @deprecated use {@link CEi#WrapKey(long, CKM, long, long)} K} instead
      */
+    @Deprecated
     public static byte[] WrapKey(long session, CKM mechanism, long wrappingKey, long key) {
-        LongRef l = new LongRef();
-        WrapKey(session, mechanism, wrappingKey, key, null, l);
-        byte[] result = new byte[(int) l.value()];
-        WrapKey(session, mechanism, wrappingKey, key, result, l);
-        return resize(result, (int) l.value());
+        return NCE.WrapKey(C.NATIVE, session, mechanism, wrappingKey, key);
     }
 
     /**
@@ -1691,10 +1663,11 @@ public class CE {
      * @param key gets new handle
      * @see C#UnwrapKey(long, CKM, long, byte[], CKA[], LongRef)
      * @see NativeProvider#C_UnwrapKey(long, CKM, long, byte[], long, CKA[], long, LongRef)
+     * @deprecated use {@link CEi#UnwrapKey(long, CKM, long, byte[], CKA[], LongRef)} instead
      */
+    @Deprecated
     public static void UnwrapKey(long session, CKM mechanism, long unwrappingKey, byte[] wrappedKey, CKA[] templ, LongRef key) {
-        long rv = C.UnwrapKey(session, mechanism, unwrappingKey, wrappedKey, templ, key);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.UnwrapKey(C.NATIVE, session, mechanism, unwrappingKey, wrappedKey, templ, key);
     }
 
     /**
@@ -1707,11 +1680,11 @@ public class CE {
      * @return key handle
      * @see C#UnwrapKey(long, CKM, long, byte[], CKA[], LongRef)
      * @see NativeProvider#C_UnwrapKey(long, CKM, long, byte[], long, CKA[], long, LongRef)
+     * @deprecated use {@link CEi#UnwrapKey(long, CKM, long, byte[], CKA...)} instead
      */
+    @Deprecated
     public static long UnwrapKey(long session, CKM mechanism, long unwrappingKey, byte[] wrappedKey, CKA... templ) {
-        LongRef result = new LongRef();
-        UnwrapKey(session, mechanism, unwrappingKey, wrappedKey, templ, result);
-        return result.value();
+        return NCE.UnwrapKey(C.NATIVE, session, mechanism, unwrappingKey, wrappedKey, templ);
     }
 
     /**
@@ -1723,10 +1696,11 @@ public class CE {
      * @param key ges new handle
      * @see C#DeriveKey(long, CKM, long, CKA[], LongRef)
      * @see NativeProvider#C_DeriveKey(long, CKM, long, CKA[], long, LongRef)
+     * @deprecated use {@link CEi#DeriveKey(long, CKM, long, CKA[], LongRef)} instead
      */
+    @Deprecated
     public static void DeriveKey(long session, CKM mechanism, long baseKey, CKA[] templ, LongRef key) {
-        long rv = C.DeriveKey(session, mechanism, baseKey, templ, key);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.DeriveKey(C.NATIVE, session, mechanism, baseKey, templ, key);
     }
 
     /**
@@ -1738,11 +1712,11 @@ public class CE {
      * @return new handle
      * @see C#DeriveKey(long, CKM, long, CKA[], LongRef)
      * @see NativeProvider#C_DeriveKey(long, CKM, long, CKA[], long, LongRef)
+     * @deprecated use {@link CEi#DeriveKey(long, CKM, long, CKA...)} instead
      */
+    @Deprecated
     public static long DeriveKey(long session, CKM mechanism, long baseKey, CKA... templ) {
-        LongRef key = new LongRef();
-        DeriveKey(session, mechanism, baseKey, templ, key);
-        return key.value();
+        return NCE.DeriveKey(C.NATIVE, session, mechanism, baseKey, templ);
     }
 
     /**
@@ -1751,10 +1725,11 @@ public class CE {
      * @param seed the seed material
      * @see C#SeedRandom(long, byte[])
      * @see NativeProvider#C_SeedRandom(long, byte[], long)
+     * @deprecated use {@link CEi#SeedRandom(long, byte[])} instead
      */
+    @Deprecated
     public static void SeedRandom(long session, byte[] seed) {
-        long rv = C.SeedRandom(session, seed);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.SeedRandom(C.NATIVE, session, seed);
     }
 
     /**
@@ -1763,10 +1738,11 @@ public class CE {
      * @param randomData receives the random data
      * @see C#GenerateRandom(long, byte[])
      * @see NativeProvider#C_GenerateRandom(long, byte[], long)
+     * @deprecated use {@link CEi#GenerateRandom(long, byte[])} instead
      */
+    @Deprecated
     public static void GenerateRandom(long session, byte[] randomData) {
-        long rv = C.GenerateRandom(session, randomData);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.GenerateRandom(C.NATIVE, session, randomData);
     }
 
     /**
@@ -1776,11 +1752,11 @@ public class CE {
      * @return random
      * @see C#GenerateRandom(long, byte[])
      * @see NativeProvider#C_GenerateRandom(long, byte[], long)
+     * @deprecated use {@link CEi#GenerateRandom(long, int)} instead
      */
+    @Deprecated
     public static byte[] GenerateRandom(long session, int randomLen) {
-        byte[] result = new byte[randomLen];
-        GenerateRandom(session, result);
-        return result;
+        return NCE.GenerateRandom(C.NATIVE, session, randomLen);
     }
 
     /**
@@ -1790,10 +1766,11 @@ public class CE {
      * @param session the session's handle
      * @see C#GetFunctionStatus(long)
      * @see NativeProvider#C_GetFunctionStatus(long)
+     * @deprecated use {@link CEi#GetFunctionStatus(long)} instead
      */
+    @Deprecated
     public static void GetFunctionStatus(long session) {
-        long rv = C.GetFunctionStatus(session);
-        if (rv != CKR.OK) throw new CKRException(rv);
+        NCE.GetFunctionStatus(C.NATIVE, session);
     }
 
     /**
@@ -1803,40 +1780,10 @@ public class CE {
      * @param session the session's handle
      * @see C#GetFunctionStatus(long)
      * @see NativeProvider#C_GetFunctionStatus(long)
+     * @deprecated use {@link CEi#CancelFunction(long)} instead
      */
+    @Deprecated
     public static void CancelFunction(long session) {
-        long rv = C.CancelFunction(session);
-        if (rv != CKR.OK) throw new CKRException(rv);
-    }
-
-    /**
-     * Set odd parity on buf and return updated buf.  Buf is modified in-place.
-     * @param buf buf to modify in place and return
-     * @return buf that was passed in
-     */
-    public static byte[] setOddParity(byte[] buf) {
-        for (int i = 0; i < buf.length; i++) {
-            int b = buf[i] & 0xff;
-            b ^= b >> 4;
-            b ^= b >> 2;
-            b ^= b >> 1;
-            buf[i] ^= (b & 1) ^ 1;
-        }
-        return buf;
-    }
-
-    /**
-     * Resize buf to specified length. If buf already size 'newSize', then return buf, else return resized buf.
-     * @param buf buf
-     * @param newSize length to resize to
-     * @return if buf already size 'newSize', then return buf, else return resized buf
-     */
-    public static byte[] resize(byte[] buf, int newSize) {
-        if (buf == null || newSize >= buf.length) {
-            return buf;
-        }
-        byte[] result = new byte[newSize];
-        System.arraycopy(buf, 0, result, 0, result.length);
-        return result;
+        NCE.CancelFunction(C.NATIVE, session);
     }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CE.java
+++ b/src/main/java/org/pkcs11/jacknji11/CE.java
@@ -1786,4 +1786,27 @@ public class CE {
     public static void CancelFunction(long session) {
         NCE.CancelFunction(C.NATIVE, session);
     }
+
+    /**
+     * Set odd parity on buf and return updated buf.  Buf is modified in-place.
+     * @param buf buf to modify in place and return
+     * @return buf that was passed in
+     * @deprecated use {@link NCE#setOddParity(byte[])} instead
+     */
+    @Deprecated
+    public static byte[] setOddParity(byte[] buf) {
+        return NCE.setOddParity(buf);
+    }
+
+    /**
+     * Resize buf to specified length. If buf already size 'newSize', then return buf, else return resized buf.
+     * @param buf buf
+     * @param newSize length to resize to
+     * @return if buf already size 'newSize', then return buf, else return resized buf
+     * @deprecated use {@link NCE#resize(byte[], int)} instead
+     */
+    @Deprecated
+    public static byte[] resize(byte[] buf, int newSize) {
+        return NCE.resize(buf, newSize);
+    }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CEi.java
+++ b/src/main/java/org/pkcs11/jacknji11/CEi.java
@@ -1,0 +1,1552 @@
+/*
+ * Copyright 2010-2011 Joel Hockey (joel.hockey@gmail.com). All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.pkcs11.jacknji11;
+
+import org.pkcs11.jacknji11.jna.JNA;
+
+/**
+ * This is the preferred java interface for calling cryptoki functions.
+ *
+ * jacknji11 provides 3 interfaces for calling cryptoki functions.
+ * <ol>
+ * <li>{@link NativeProvider} provides the lowest level
+ * direct mapping to the <code>'C_*'</code> functions.  There is little
+ * reason why you would ever want to invoke it directly, but you can.
+ * <li>{@link C} provides the exact same functions
+ * as {@link NativeProvider} by calling through to the
+ * corresponding native method.  The <code>'C_'</code> at the start of the
+ * function name is removed since the <code>'C.'</code> when you call the
+ * static methods of this class looks similar.  In addition to calling
+ * the native methods, {@link C} provides logging
+ * through apache commons logging.  You can use this if you require fine-grain
+ * control over something such as checking
+ * {@link CKR} return codes.
+ * <li>{@link CEi} (<b>C</b>ryptoki
+ * with <b>E</b>xceptions) provides the most user-friendly interface
+ * and is the preferred interface to use.  It calls
+ * related function(s) in {@link C},
+ * and converts any non-zero return values into a
+ * {@link CKRException}.  It automatically resizes
+ * arrays and other helpful things.
+ * </ol>
+ *
+ * @author Joel Hockey (joel.hockey@gmail.com)
+ */
+public class CEi {
+
+    private final NativeProvider nativeProvider;
+
+    public CEi(NativeProvider nativeProvider) {
+        this.nativeProvider = nativeProvider;
+    }
+
+    public CEi() {
+        this(new JNA(NC.getLibraryName()));
+    }
+
+    /**
+     * Initialize cryptoki.
+     * @see NC#Initialize(NativeProvider)
+     * @see NativeProvider#C_Initialize(CK_C_INITIALIZE_ARGS)
+     */
+    public void Initialize() {
+        NCE.Initialize(nativeProvider);
+    }
+
+    /**
+     * Called to indicate that an application is finished with the Cryptoki library.
+     * @see NC#Finalize(NativeProvider)
+     * @see NativeProvider#C_Finalize(NativePointer)
+     */
+    public void Finalize() {
+        NCE.Finalize(nativeProvider);
+    }
+
+    /**
+     * Returns general information about Cryptoki.
+     * @param info location that receives information
+     * @see NC#GetInfo(NativeProvider, CK_INFO)
+     * @see NativeProvider#C_GetInfo(CK_INFO)
+     */
+    public void GetInfo(CK_INFO info) {
+        NCE.GetInfo(nativeProvider, info);
+    }
+
+    /**
+     * Returns general information about Cryptoki.
+     * @return info
+     * @see NC#GetInfo(NativeProvider, CK_INFO)
+     * @see NativeProvider#C_GetInfo(CK_INFO)
+     */
+    public CK_INFO GetInfo() {
+        return NCE.GetInfo(nativeProvider);
+    }
+
+    /**
+     * Obtains a list of slots in the system.
+     * @param tokenPresent only slots with tokens?
+     * @param slotList receives array of slot IDs
+     * @param count receives the number of slots
+     * @see NC#GetSlotList(NativeProvider, boolean, long[], LongRef)
+     * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef)
+     */
+    public void GetSlotList(boolean tokenPresent, long[] slotList, LongRef count) {
+        NCE.GetSlotList(nativeProvider, tokenPresent, slotList, count);
+    }
+
+    /**
+     * Obtains a list of slots in the system.
+     * @param tokenPresent only slots with tokens?
+     * @return slot list
+     * @see NC#GetSlotList(NativeProvider, boolean, long[], LongRef)
+     * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef)
+     */
+    public long[] GetSlotList(boolean tokenPresent) {
+        return NCE.GetSlotList(nativeProvider, tokenPresent);
+    }
+
+    /**
+     * Return first slot with given label else throw CKRException.
+     * @param label label of slot to find
+     * @return slot id or CKRException if no slot found
+     * @see NC#GetSlotList(NativeProvider, boolean, long[], LongRef)
+     * @see NC#GetTokenInfo(NativeProvider, long, CK_TOKEN_INFO)
+     * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef)
+     * @see NativeProvider#C_GetTokenInfo(long, CK_TOKEN_INFO)
+     */
+    public long GetSlot(String label) {
+        return NCE.GetSlot(nativeProvider, label);
+    }
+
+    /**
+     * Obtains information about a particular slot in the system.
+     * @param slotID the ID of the slot
+     * @param info receives the slot information
+     * @see NC#GetSlotInfo(NativeProvider, long, CK_SLOT_INFO)
+     * @see NativeProvider#C_GetSlotInfo(long, CK_SLOT_INFO)
+     */
+    public void GetSlotInfo(long slotID, CK_SLOT_INFO info) {
+        NCE.GetSlotInfo(nativeProvider, slotID, info);
+    }
+
+    /**
+     * Obtains information about a particular slot in the system.
+     * @param slotID the ID of the slot
+     * @return slot info
+     * @see NC#GetSlotInfo(NativeProvider, long, CK_SLOT_INFO)
+     * @see NativeProvider#C_GetSlotInfo(long, CK_SLOT_INFO)
+     */
+    public CK_SLOT_INFO GetSlotInfo(long slotID) {
+        return NCE.GetSlotInfo(nativeProvider, slotID);
+    }
+
+    /**
+     * Obtains information about a particular token in the system.
+     * @param slotID ID of the token's slot
+     * @param info receives the token information
+     * @see NC#GetTokenInfo(NativeProvider, long, CK_TOKEN_INFO)
+     * @see NativeProvider#C_GetTokenInfo(long, CK_TOKEN_INFO)
+     */
+    public void GetTokenInfo(long slotID, CK_TOKEN_INFO info) {
+        NCE.GetTokenInfo(nativeProvider, slotID, info);
+    }
+
+    /**
+     * Obtains information about a particular token in the system.
+     * @param slotID ID of the token's slot
+     * @return token info
+     * @see NC#GetTokenInfo(NativeProvider, long, CK_TOKEN_INFO)
+     * @see NativeProvider#C_GetTokenInfo(long, CK_TOKEN_INFO)
+     */
+    public CK_TOKEN_INFO GetTokenInfo(long slotID) {
+        return NCE.GetTokenInfo(nativeProvider, slotID);
+    }
+
+    /**
+     * Waits for a slot event (token insertion, removal, etc.) to occur.
+     * @param flags blocking/nonblocking flag
+     * @param slot location that receives the slot ID
+     * @param pReserved reserved.  Should be null
+     * @see NC#WaitForSlotEvent(NativeProvider, long, LongRef, NativePointer)
+     * @see NativeProvider#C_WaitForSlotEvent(long, LongRef, NativePointer)
+     */
+    public void WaitForSlotEvent(long flags, LongRef slot, NativePointer pReserved) {
+        NCE.WaitForSlotEvent(nativeProvider, flags, slot, pReserved);
+    }
+
+    /**
+     * Obtains a list of mechanism types supported by a token.
+     * @param slotID ID of token's slot
+     * @param mechanismList gets mechanism array
+     * @param count gets # of mechanisms
+     * @see NC#GetMechanismList(NativeProvider, long, long[], LongRef)
+     * @see NativeProvider#C_GetMechanismList(long, long[], LongRef)
+     */
+    public void GetMechanismList(long slotID, long[] mechanismList, LongRef count) {
+        NCE.GetMechanismList(nativeProvider, slotID, mechanismList, count);
+    }
+
+    /**
+     * Obtains a list of mechanism types supported by a token.
+     * @param slotID ID of token's slot
+     * @return mechanism list (array of {@link CKM})
+     * @see NC#GetMechanismList(NativeProvider, long, long[], LongRef)
+     * @see NativeProvider#C_GetMechanismList(long, long[], LongRef)
+     */
+    public long[] GetMechanismList(long slotID) {
+        return NCE.GetMechanismList(nativeProvider, slotID);
+    }
+
+    /**
+     * Obtains information about a particular mechanism possibly supported by a token.
+     * @param slotID ID of the token's slot
+     * @param type {@link CKM} type of mechanism
+     * @param info receives mechanism info
+     * @see NC#GetMechanismInfo(NativeProvider, long, long, CK_MECHANISM_INFO)
+     * @see NativeProvider#C_GetMechanismInfo(long, long, CK_MECHANISM_INFO)
+     */
+    public void GetMechanismInfo(long slotID, long type, CK_MECHANISM_INFO info) {
+        NCE.GetMechanismInfo(nativeProvider, slotID, type, info);
+    }
+
+    /**
+     * Obtains information about a particular mechanism possibly supported by a token.
+     * @param slotID ID of the token's slot
+     * @return mechanism info
+     * @see NC#GetMechanismInfo(NativeProvider, long, long, CK_MECHANISM_INFO)
+     * @see NativeProvider#C_GetMechanismInfo(long, long, CK_MECHANISM_INFO)
+     */
+    public CK_MECHANISM_INFO GetMechanismInfo(long slotID, long type) {
+        return NCE.GetMechanismInfo(nativeProvider, slotID, type);
+    }
+
+    /**
+     * Initialises a token.  Pad or truncate label if required.
+     * @param slotID ID of the token's slot
+     * @param pin the SO's initial PIN
+     * @param label 32-byte token label (space padded).  If not 32 bytes, then
+     * it will be padded or truncated as required
+     * @see NC#InitToken(NativeProvider, long, byte[], byte[])
+     * @see NativeProvider#C_InitToken(long, byte[], long, byte[])
+     */
+    public void InitToken(long slotID, byte[] pin, byte[] label) {
+        NCE.InitToken(nativeProvider, slotID, pin, label);
+    }
+
+    /**
+     * Initialise normal user with PIN.
+     * @param session the session's handle
+     * @param pin the normal user's PIN
+     * @see NC#InitPIN(NativeProvider, long, byte[])
+     * @see NativeProvider#C_InitPIN(long, byte[], long)
+     */
+    public void InitPIN(long session, byte[] pin) {
+        NCE.InitPIN(nativeProvider, session, pin);
+    }
+
+    /**
+     * Change PIN.
+     * @param session the session's handle
+     * @param oldPin old PIN
+     * @param newPin new PIN
+     * @see NC#SetPIN(NativeProvider, long, byte[], byte[])
+     * @see NativeProvider#C_SetPIN(long, byte[], long, byte[], long)
+     */
+    public void SetPIN(long session, byte[] oldPin, byte[] newPin) {
+        NCE.SetPIN(nativeProvider, session, oldPin, newPin);
+    }
+
+    /**
+     * Opens a session between an application and a token.
+     * @param slotID the slot's ID
+     * @param flags from {@link CK_SESSION_INFO}
+     * @param application passed to callback (ok to leave it null)
+     * @param notify callback function (ok to leave it null)
+     * @param session gets session handle
+     * @see NC#OpenSession(NativeProvider, long, long, NativePointer, CK_NOTIFY, LongRef)
+     * @see NativeProvider#C_OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
+     */
+    public void OpenSession(long slotID, long flags, NativePointer application, CK_NOTIFY notify, LongRef session) {
+        NCE.OpenSession(nativeProvider, slotID, flags, application, notify, session);
+    }
+
+    /**
+     * Opens a session between an application and a token.
+     * @param slotID the slot's ID
+     * @param flags from {@link CK_SESSION_INFO}
+     * @param application passed to callback (ok to leave it null)
+     * @param notify callback function (ok to leave it null)
+     * @return session handle
+     * @see NC#OpenSession(NativeProvider, long, long, NativePointer, CK_NOTIFY, LongRef)
+     * @see NativeProvider#C_OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
+     */
+    public long OpenSession(long slotID, long flags, NativePointer application, CK_NOTIFY notify) {
+        return NCE.OpenSession(nativeProvider, slotID, flags, application, notify);
+    }
+
+    /**
+     * Opens a session between an application and a token using {@link CK_SESSION_INFO#CKF_RW_SESSION and CK_SESSION_INFO#CKF_SERIAL_SESSION}
+     * and null application and notify.
+     * @param slotID the slot's ID
+     * @return session handle
+     * @see NC#OpenSession(NativeProvider, long, long, NativePointer, CK_NOTIFY, LongRef)
+     * @see NativeProvider#C_OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
+     */
+    public long OpenSession(long slotID) {
+        return NCE.OpenSession(nativeProvider, slotID);
+    }
+
+    /**
+     * Closes a session between an application and a token.
+     * @param session the session's handle
+     * @see NC#CloseSession(NativeProvider, long)
+     * @see NativeProvider#C_CloseSession(long)
+     */
+    public void CloseSession(long session) {
+        NCE.CloseSession(nativeProvider, session);
+    }
+
+    /**
+     * Closes all sessions with a token.
+     * @param slotID the token's slot
+     * @see NC#CloseAllSessions(NativeProvider, long)
+     * @see NativeProvider#C_CloseAllSessions(long)
+     */
+    public void CloseAllSessions(long slotID) {
+        NCE.CloseAllSessions(nativeProvider, slotID);
+    }
+
+    /**
+     * Obtains information about the session.
+     * @param session the session's handle
+     * @param info receives session info
+     * @see NC#GetSessionInfo(NativeProvider, long, CK_SESSION_INFO)
+     * @see NativeProvider#C_GetSessionInfo(long, CK_SESSION_INFO)
+     */
+    public void GetSessionInfo(long session, CK_SESSION_INFO info) {
+        NCE.GetSessionInfo(nativeProvider, session, info);
+    }
+
+    /**
+     * Obtains information about the session.
+     * @param session the session's handle
+     * @return session info
+     * @see NC#GetSessionInfo(NativeProvider, long, CK_SESSION_INFO)
+     * @see NativeProvider#C_GetSessionInfo(long, CK_SESSION_INFO)
+     */
+    public CK_SESSION_INFO GetSessionInfo(long session) {
+        return NCE.GetSessionInfo(nativeProvider, session);
+    }
+
+    /**
+     * Obtains the state of the cryptographic operation.
+     * @param session the session's handle
+     * @param operationState gets state
+     * @param operationStateLen gets state length
+     * @see NC#GetOperationState(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_GetOperationState(long, byte[], LongRef)
+     */
+    public void GetOperationState(long session, byte[] operationState, LongRef operationStateLen) {
+        NCE.GetOperationState(nativeProvider, session, operationState, operationStateLen);
+    }
+
+    /**
+     * Obtains the state of the cryptographic operation.
+     * @param session the session's handle
+     * @return operation state
+     * @see NC#GetOperationState(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_GetOperationState(long, byte[], LongRef)
+     */
+    public byte[] GetOperationState(long session) {
+        return NCE.GetOperationState(nativeProvider, session);
+    }
+
+    /**
+     * Restores the state of the cryptographic operation in a session.
+     * @param session the session's handle
+     * @param operationState holds state
+     * @param encryptionKey en/decryption key
+     * @param authenticationKey sign/verify key
+     * @see NC#SetOperationState(NativeProvider, long, byte[], long, long)
+     * @see NativeProvider#C_SetOperationState(long, byte[], long, long, long)
+     */
+    public void SetOperationState(long session, byte[] operationState, long encryptionKey, long authenticationKey) {
+        NCE.SetOperationState(nativeProvider, session, operationState, encryptionKey, authenticationKey);
+    }
+
+    /**
+     * Logs a user into a token.  Ignores CKR=0x00000100: USER_ALREADY_LOGGED_IN
+     * @param session the session's handle
+     * @param userType the user type from {@link CKU}
+     * @param pin the user's PIN
+     * @see NC#Login(NativeProvider, long, long, byte[])
+     * @see NativeProvider#C_Login(long, long, byte[], long)
+     */
+    public void Login(long session, long userType, byte[] pin) {
+        NCE.Login(nativeProvider, session, userType, pin);
+    }
+
+    /**
+     * Logs a normal user into a token.
+     * @param session the session's handle
+     * @param pin the normal user's PIN
+     * @see NC#Login(NativeProvider, long, long, byte[])
+     * @see NativeProvider#C_Login(long, long, byte[], long)
+     */
+    public void LoginUser(long session, byte[] pin) {
+        NCE.LoginUser(nativeProvider, session, pin);
+    }
+
+    /**
+     * Los a normal user into a token.
+     * @param session the session's handle
+     * @param pin the normal user's PIN encoded in a single byte encoding format such as ISO8859-1
+     * @see NC#Login(NativeProvider, long, long, byte[])
+     * @see NativeProvider#C_Login(long, long, byte[], long)
+     */
+    public void LoginUser(long session, String pin) {
+        NCE.LoginUser(nativeProvider, session, pin);
+    }
+
+    /**
+     * Logs SO into a token.
+     * @param session the session's handle
+     * @param pin SO PIN
+     * @see NC#Login(NativeProvider, long, long, byte[])
+     * @see NativeProvider#C_Login(long, long, byte[], long)
+     */
+    public void LoginSO(long session, byte[] pin) {
+        NCE.LoginSO(nativeProvider, session, pin);
+    }
+
+    /**
+     * Logs SO into a token.
+     * @param session the session's handle
+     * @param pin SO PIN encoded in a single byte encoding format such as ISO8859-1
+     * @see NC#Login(NativeProvider, long, long, byte[])
+     * @see NativeProvider#C_Login(long, long, byte[], long)
+     */
+    public void LoginSO(long session, String pin) {
+        NCE.LoginSO(nativeProvider, session, pin);
+    }
+
+    /**
+     * Logs a user out from a token.
+     * @param session the session's handle
+     * @see NC#Logout(NativeProvider, long)
+     * @see NativeProvider#C_Logout(long)
+     */
+    public void Logout(long session) {
+        NCE.Logout(nativeProvider, session);
+    }
+
+    /**
+     * Creates a new object.
+     * @param session the session's handle
+     * @param templ the objects template
+     * @param object gets new object's handle
+     * @see NC#CreateObject(NativeProvider, long, CKA[], LongRef)
+     * @see NativeProvider#C_CreateObject(long, CKA[], long, LongRef)
+     */
+    public void CreateObject(long session, CKA[] templ, LongRef object) {
+        NCE.CreateObject(nativeProvider, session, templ, object);
+    }
+
+    /**
+     * Creates a new object.
+     * @param session the session's handle
+     * @return new object handle
+     * @see NC#CreateObject(NativeProvider, long, CKA[], LongRef)
+     * @see NativeProvider#C_CreateObject(long, CKA[], long, LongRef)
+     */
+    public long CreateObject(long session, CKA... templ) {
+        return NCE.CreateObject(nativeProvider, session, templ);
+    }
+
+    /**
+     * Copies an object, creating a new object for the copy.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @param templ template for new object
+     * @param newObject receives handle of copy
+     * @see NC#CopyObject(NativeProvider, long, long, CKA[], LongRef)
+     * @see NativeProvider#C_CopyObject(long, long, CKA[], long, LongRef)
+     */
+    public void CopyObject(long session, long object, CKA[] templ, LongRef newObject) {
+        NCE.CopyObject(nativeProvider, session, object, templ, newObject);
+    }
+
+    /**
+     * Copies an object, creating a new object for the copy.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @param templ template for new object
+     * @return new object handle
+     * @see NC#CopyObject(NativeProvider, long, long, CKA[], LongRef)
+     * @see NativeProvider#C_CopyObject(long, long, CKA[], long, LongRef)
+     */
+    public long CopyObject(long session, long object, CKA... templ) {
+        return NCE.CopyObject(nativeProvider, session, object, templ);
+    }
+
+    /**
+     * Destroys an object.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @see NC#DestroyObject(NativeProvider, long, long)
+     * @see NativeProvider#C_DestroyObject(long, long)
+     */
+    public void DestroyObject(long session, long object) {
+        NCE.DestroyObject(nativeProvider, session, object);
+    }
+
+    /**
+     * Gets the size of an object in bytes.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @param size receives the size of object
+     * @see NC#GetObjectSize(NativeProvider, long, long, LongRef)
+     * @see NativeProvider#C_GetObjectSize(long, long, LongRef)
+     */
+    public void GetObjectSize(long session, long object, LongRef size) {
+        NCE.GetObjectSize(nativeProvider, session, object, size);
+    }
+
+    /**
+     * Gets the size of an object in bytes.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @return size of object in bytes
+     * @see NC#GetObjectSize(NativeProvider, long, long, LongRef)
+     * @see NativeProvider#C_GetObjectSize(long, long, LongRef)
+     */
+    public long GetObjectSize(long session, long object) {
+        return NCE.GetObjectSize(nativeProvider, session, object);
+    }
+
+    /**
+     * Obtains the value of one or more object attributes.
+     * @param session the session's handle
+     * @param object the objects's handle
+     * @param templ specifies attributes, gets values
+     * @see NC#GetAttributeValue(NativeProvider, long, long, CKA[])
+     * @see NativeProvider#C_GetAttributeValue(long, long, CKA[], long)
+     */
+    public void GetAttributeValue(long session, long object, CKA... templ) {
+        NCE.GetAttributeValue(nativeProvider, session, object, templ);
+    }
+
+    /**
+     * Obtains the value of one attributes, or returns CKA with null value if attribute doesn't exist.
+     * @param session the session's handle
+     * @param object the objects's handle
+     * @param cka {@link CKA} type
+     * @see NC#GetAttributeValue(NativeProvider, long, long, CKA[])
+     * @see NativeProvider#C_GetAttributeValue(long, long, CKA[], long)
+     */
+    public CKA GetAttributeValue(long session, long object, long cka) {
+        return NCE.GetAttributeValue(nativeProvider, session, object, cka);
+    }
+
+    /**
+     * Obtains the value of one or more object attributes. Sets value to null
+     * if object does not include attribute.
+     * @param session the session's handle
+     * @param object the objects's handle
+     * @param types {@link CKA} attribute types to get
+     * @return attribute values
+     * @see NC#GetAttributeValue(NativeProvider, long, long, CKA[])
+     * @see NativeProvider#C_GetAttributeValue(long, long, CKA[], long)
+     */
+    public CKA[] GetAttributeValue(long session, long object, long... types) {
+        return NCE.GetAttributeValue(nativeProvider, session, object, types);
+    }
+
+    /**
+     * Modifies the values of one or more object attributes.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @param templ specifies attributes and values
+     * @see NC#SetAttributeValue(NativeProvider, long, long, CKA[])
+     * @see NativeProvider#C_SetAttributeValue(long, long, CKA[], long)
+     */
+    public void SetAttributeValue(long session, long object, CKA... templ) {
+        NCE.SetAttributeValue(nativeProvider, session, object, templ);
+    }
+
+    /**
+     * Initialises a search for token and session objects that match a template.
+     * @param session the session's handle
+     * @param templ attribute values to match
+     * @see NC#FindObjectsInit(NativeProvider, long, CKA[])
+     * @see NativeProvider#C_FindObjectsInit(long, CKA[], long)
+     */
+    public void FindObjectsInit(long session, CKA... templ) {
+        NCE.FindObjectsInit(nativeProvider, session, templ);
+    }
+
+    /**
+     * Continues a search for token and session objects that match a template,
+     * obtaining additional object handles.
+     * @param session the session's handle
+     * @param found gets object handles
+     * @param objectCount number of object handles returned
+     * @see NC#FindObjects(NativeProvider, long, long[], LongRef)
+     * @see NativeProvider#C_FindObjects(long, long[], long, LongRef)
+     */
+    public void FindObjects(long session, long[] found, LongRef objectCount) {
+        NCE.FindObjects(nativeProvider, session, found, objectCount);
+    }
+
+    /**
+     * Continues a search for token and session objects that match a template,
+     * obtaining additional object handles.
+     * @param session the session's handle
+     * @param maxObjects maximum objects to return
+     * @return list of object handles
+     * @see NC#FindObjects(NativeProvider, long, long[], LongRef)
+     * @see NativeProvider#C_FindObjects(long, long[], long, LongRef)
+     */
+    public long[] FindObjects(long session, int maxObjects) {
+        return NCE.FindObjects(nativeProvider, session, maxObjects);
+    }
+
+    /**
+     * Finishes a search for token and session objects.
+     * @param session the session's handle
+     * @see NC#FindObjectsFinal(NativeProvider, long)
+     * @see NativeProvider#C_FindObjectsFinal(long)
+     */
+    public void FindObjectsFinal(long session) {
+        NCE.FindObjectsFinal(nativeProvider, session);
+    }
+
+    /**
+     * Single-part search for token and session objects that match a template.
+     * @param session the session's handle
+     * @param templ attribute values to match
+     * @return all objects matching
+     * @see NC#FindObjectsInit(NativeProvider, long, CKA[])
+     * @see NativeProvider#C_FindObjectsInit(long, CKA[], long)
+     */
+    public long[] FindObjects(long session, CKA... templ) {
+        return NCE.FindObjects(nativeProvider, session, templ);
+    }
+
+    /**
+     * Initialises an encryption operation.
+     * @param session the session's handle
+     * @param mechanism the encryption mechanism
+     * @param key handle of encryption key
+     * @see NC#EncryptInit(NativeProvider, long, CKM, long)
+     * @see NativeProvider#C_EncryptInit(long, CKM, long)
+     */
+    public void EncryptInit(long session, CKM mechanism, long key) {
+        NCE.EncryptInit(nativeProvider, session, mechanism, key);
+    }
+
+    /**
+     * Encrypts single-part data.
+     * @param session the session's handle
+     * @param data the plaintext data
+     * @param encryptedData gets ciphertext
+     * @param encryptedDataLen gets c-text size
+     * @see NC#Encrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     */
+    public void Encrypt(long session, byte[] data, byte[] encryptedData, LongRef encryptedDataLen) {
+        NCE.Encrypt(nativeProvider, session, data, encryptedData, encryptedDataLen);
+    }
+
+    /**
+     * Encrypts single-part data with 2 calls.  First call determines
+     * size of result which may include padding, second call does encrypt.
+     * @param session the session's handle
+     * @param data the plaintext data
+     * @return encrypted data
+     * @see NC#Encrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] EncryptPad(long session, byte[] data) {
+        return NCE.EncryptPad(nativeProvider, session, data);
+    }
+
+    /**
+     * Encrypts single-part data with single call assuming result
+     * has no padding and is same size as input.
+     * @param session the session's handle
+     * @param data the plaintext data
+     * @return encrypted data
+     * @see NC#Encrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] Encrypt(long session, byte[] data) {
+        return NCE.Encrypt(nativeProvider, session, data);
+    }
+
+    /**
+     * Continues a multiple-part encryption.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @param encryptedPart get ciphertext
+     * @param encryptedPartLen gets c-text size
+     * @see NC#EncryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_EncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public void EncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
+        NCE.EncryptUpdate(nativeProvider, session, part, encryptedPart, encryptedPartLen);
+    }
+
+    /**
+     * Continues a multiple-part encryption.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @return encrypted part
+     * @see NC#EncryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_EncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] EncryptUpdate(long session, byte[] part) {
+        return NCE.EncryptUpdate(nativeProvider, session, part);
+    }
+
+    /**
+     * Finishes a multiple-part encryption.
+     * @param session the session's handle
+     * @param lastEncryptedPart last c-text
+     * @param lastEncryptedPartLen gets last size
+     * @see NC#EncryptFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_EncryptFinal(long, byte[], LongRef)
+     */
+    public void EncryptFinal(long session, byte[] lastEncryptedPart, LongRef lastEncryptedPartLen) {
+        NCE.EncryptFinal(nativeProvider, session, lastEncryptedPart, lastEncryptedPartLen);
+    }
+
+    /**
+     * Finishes a multiple-part encryption.
+     * @param session the session's handle
+     * @return last encrypted part
+     * @see NC#EncryptFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_EncryptFinal(long, byte[], LongRef)
+     */
+    public byte[] EncryptFinal(long session) {
+        return NCE.EncryptFinal(nativeProvider, session);
+    }
+
+    /**
+     * Encrypts single-part data with 2 calls.  First call determines
+     * size of result which may include padding, second call does encrypt.
+     * @param session the session's handle
+     * @param mechanism the encryption mechanism
+     * @param key handle of encryption key
+     * @param data the plaintext data
+     * @return encrypted data
+     * @see NC#Encrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] EncryptPad(long session, CKM mechanism, long key, byte[] data) {
+        return NCE.EncryptPad(nativeProvider, session, mechanism, key, data);
+    }
+
+    /**
+     * Encrypts single-part data with single call assuming result
+     * has no padding and is same size as input.
+     * @param session the session's handle
+     * @param mechanism the encryption mechanism
+     * @param key handle of encryption key
+     * @param data the plaintext data
+     * @return encrypted data
+     * @see NC#Encrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] Encrypt(long session, CKM mechanism, long key, byte[] data) {
+        return NCE.Encrypt(nativeProvider, session, mechanism, key, data);
+    }
+
+    /**
+     * Initialises a decryption operation.
+     * @param session the session's handle
+     * @param mechanism the decryption mechanism
+     * @param key handle of decryption key
+     * @see NC#DecryptInit(NativeProvider, long, CKM, long)
+     * @see NativeProvider#C_DecryptInit(long, CKM, long)
+     */
+    public void DecryptInit(long session, CKM mechanism, long key) {
+        NCE.DecryptInit(nativeProvider, session, mechanism, key);
+    }
+
+    /**
+     * Decrypts encrypted data in a single part.
+     * @param session the session's handle
+     * @param encryptedData cipertext
+     * @param data gets plaintext
+     * @param dataLen gets p-text size
+     * @see NC#Decrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     */
+    public void Decrypt(long session, byte[] encryptedData, byte[] data, LongRef dataLen) {
+        NCE.Decrypt(nativeProvider, session, encryptedData, data, dataLen);
+    }
+
+    /**
+     * Decrypts encrypted data in a single-part with 2 calls.  First call determines
+     * size of result which may have padding removed, second call does decrypt.
+     * @param session the session's handle
+     * @param encryptedData cipertext
+     * @return plaintext
+     * @see NC#Decrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] DecryptPad(long session, byte[] encryptedData) {
+        return NCE.DecryptPad(nativeProvider, session, encryptedData);
+    }
+
+    /**
+     * Decrypts encrypted data in a single-part with 1 single call
+     * assuming result is not larger than input.
+     * @param session the session's handle
+     * @param encryptedData cipertext
+     * @return plaintext
+     * @see NC#Decrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] Decrypt(long session, byte[] encryptedData) {
+        return NCE.Decrypt(nativeProvider, session, encryptedData);
+    }
+
+    /**
+     * Continues a multiple-part decryption.
+     * @param session the session's handle
+     * @param encryptedPart encrypted data
+     * @param data gets plaintext
+     * @param dataLen get p-text size
+     * @see NC#DecryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_DecryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public void DecryptUpdate(long session, byte[] encryptedPart, byte[] data, LongRef dataLen) {
+        NCE.DecryptUpdate(nativeProvider, session, encryptedPart, data, dataLen);
+    }
+
+    /**
+     * Continues a multiple-part decryption.
+     * @param session the session's handle
+     * @param encryptedPart encrypted data
+     * @return plaintext
+     * @see NC#DecryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_DecryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] DecryptUpdate(long session, byte[] encryptedPart) {
+        return NCE.DecryptUpdate(nativeProvider, session, encryptedPart);
+    }
+
+    /**
+     * Finishes a multiple-part decryption.
+     * @param session the session's handle
+     * @param lastPart gets plaintext
+     * @param lastPartLen p-text size
+     * @see NC#DecryptFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_DecryptFinal(long, byte[], LongRef)
+     */
+    public void DecryptFinal(long session, byte[] lastPart, LongRef lastPartLen) {
+        NCE.DecryptFinal(nativeProvider, session, lastPart, lastPartLen);
+    }
+
+    /**
+     * Finishes a multiple-part decryption.
+     * @param session the session's handle
+     * @return last part of plaintext
+     * @see NC#DecryptFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_DecryptFinal(long, byte[], LongRef)
+     */
+    public byte[] DecryptFinal(long session) {
+        return NCE.DecryptFinal(nativeProvider, session);
+    }
+
+    /**
+     * Decrypts encrypted data in a single-part with 2 calls.  First call determines
+     * size of result which may have padding removed, second call does decrypt.
+     * @param session the session's handle
+     * @param mechanism the decryption mechanism
+     * @param key handle of decryption key
+     * @param encryptedData cipertext
+     * @return plaintext
+     * @see NC#Decrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] DecryptPad(long session, CKM mechanism, long key, byte[] encryptedData) {
+        return NCE.DecryptPad(nativeProvider, session, mechanism, key, encryptedData);
+    }
+
+    /**
+     * Decrypts encrypted data in a single-part with 1 single call
+     * assuming result is not larger than input.
+     * @param session the session's handle
+     * @param mechanism the decryption mechanism
+     * @param key handle of decryption key
+     * @param encryptedData cipertext
+     * @return plaintext
+     * @see NC#Decrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] Decrypt(long session, CKM mechanism, long key, byte[] encryptedData) {
+        return NCE.Decrypt(nativeProvider, session, mechanism, key, encryptedData);
+    }
+
+    /**
+     * Initialises a message-digesting operation.
+     * @param session the session's handle
+     * @param mechanism the digesting mechanism
+     * @see NC#DigestInit(NativeProvider, long, CKM)
+     * @see NativeProvider#C_DigestInit(long, CKM)
+     */
+    public void DigestInit(long session, CKM mechanism) {
+        NCE.DigestInit(nativeProvider, session, mechanism);
+    }
+
+    /**
+     * Digests data in a single part.
+     * @param session the session's handle
+     * @param data data to be digested
+     * @param digest gets the message digest
+     * @param digestLen gets digest length
+     * @see NC#Digest(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Digest(long, byte[], long, byte[], LongRef)
+     */
+    public void Digest(long session, byte[] data, byte[] digest, LongRef digestLen) {
+        NCE.Digest(nativeProvider, session, data, digest, digestLen);
+    }
+
+    /**
+     * Digests data in a single part.
+     * @param session the session's handle
+     * @param data data to be digested
+     * @return digest
+     * @see NC#Digest(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Digest(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] Digest(long session, byte[] data) {
+        return NCE.Digest(nativeProvider, session, data);
+    }
+
+    /**
+     * Continues a multiple-part message-digesting.
+     * @param session the session's handle
+     * @param part data to be digested
+     * @see NC#DigestUpdate(NativeProvider, long, byte[])
+     * @see NativeProvider#C_DigestUpdate(long, byte[], long)
+     */
+    public void DigestUpdate(long session, byte[] part) {
+        NCE.DigestUpdate(nativeProvider, session, part);
+    }
+
+    /**
+     * Continues a multi-part message-digesting operation, by digesting
+     * the value of a secret key as part of the data already digested.
+     * @param session the session's handle
+     * @param key secret key to digest
+     * @see NC#DigestKey(NativeProvider, long, long)
+     * @see NativeProvider#C_DigestKey(long, long)
+     */
+    public void DigestKey(long session, long key) {
+        NCE.DigestKey(nativeProvider, session, key);
+    }
+
+    /**
+     * Finishes a multiple-part message-digesting operation.
+     * @param session the session's handle
+     * @param digest gets the message digest
+     * @param digestLen gets byte count of digest
+     * @see NC#DigestFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_DigestFinal(long, byte[], LongRef)
+     */
+    public void DigestFinal(long session, byte[] digest, LongRef digestLen) {
+        NCE.DigestFinal(nativeProvider, session, digest, digestLen);
+    }
+
+    /**
+     * Finishes a multiple-part message-digesting operation.
+     * @param session the session's handle
+     * @return digest
+     * @see NC#DigestFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_DigestFinal(long, byte[], LongRef)
+     */
+    public byte[] DigestFinal(long session) {
+        return NCE.DigestFinal(nativeProvider, session);
+    }
+
+    /**
+     * Digests data in a single part.
+     * @param session the session's handle
+     * @param mechanism the digesting mechanism
+     * @param data data to be digested
+     * @return digest
+     * @see NC#Digest(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Digest(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] Digest(long session, CKM mechanism, byte[] data) {
+        return NCE.Digest(nativeProvider, session, mechanism, data);
+    }
+
+    /**
+     * Initialises a signature (private key encryption) operation, where
+     * the signature is (will be) an appendix to the data, and plaintext
+     * cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the signature mechanism
+     * @param key handle of signature key
+     * @see NC#SignInit(NativeProvider, long, CKM, long)
+     * @see NativeProvider#C_SignInit(long, CKM, long)
+     */
+    public void SignInit(long session, CKM mechanism, long key) {
+        NCE.SignInit(nativeProvider, session, mechanism, key);
+    }
+
+    /**
+     * Signs (encrypts with private key) data in a single part, where the signature is (will be)
+     * an appendix to the data, and plaintext cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param data the data to sign
+     * @param signature gets the signature
+     * @param signatureLen gets signature length
+     * @see NC#Sign(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Sign(long, byte[], long, byte[], LongRef)
+     */
+    public void Sign(long session, byte[] data, byte[] signature, LongRef signatureLen) {
+        NCE.Sign(nativeProvider, session, data, signature, signatureLen);
+    }
+
+    /**
+     * Signs (encrypts with private key) data in a single part, where the signature is (will be)
+     * an appendix to the data, and plaintext cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param data the data to sign
+     * @return signature
+     * @see NC#Sign(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Sign(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] Sign(long session, byte[] data) {
+        return NCE.Sign(nativeProvider, session, data);
+    }
+
+    /**
+     * Continues a multiple-part signature operation where the signature is
+     * (will be) an appendix to the data, and plaintext cannot be recovered from
+     * the signature.
+     * @param session the session's handle
+     * @param part data to sign
+     * @see NC#SignUpdate(NativeProvider, long, byte[])
+     * @see NativeProvider#C_SignUpdate(long, byte[], long)
+     */
+    public void SignUpdate(long session, byte[] part) {
+        NCE.SignUpdate(nativeProvider, session, part);
+    }
+
+    /**
+     * Finishes a multiple-part signature operation, returning the signature.
+     * @param session the session's handle
+     * @param signature gets the signature
+     * @param signatureLen gets signature length
+     * @see NC#SignFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_SignFinal(long, byte[], LongRef)
+     */
+    public void SignFinal(long session, byte[] signature, LongRef signatureLen) {
+        NCE.SignFinal(nativeProvider, session, signature, signatureLen);
+    }
+
+    /**
+     * Finishes a multiple-part signature operation, returning the signature.
+     * @param session the session's handle
+     * @return signature
+     * @see NC#SignFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_SignFinal(long, byte[], LongRef)
+     */
+    public byte[] SignFinal(long session) {
+        return NCE.SignFinal(nativeProvider, session);
+    }
+
+    /**
+     * Signs (encrypts with private key) data in a single part, where the signature is (will be)
+     * an appendix to the data, and plaintext cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the signature mechanism
+     * @param key handle of signature key
+     * @param data the data to sign
+     * @return signature
+     * @see NC#Sign(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Sign(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] Sign(long session, CKM mechanism, long key, byte[] data) {
+        return NCE.Sign(nativeProvider, session, mechanism, key, data);
+    }
+
+    /**
+     * Initialises a signature operation, where the data can be recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the signature mechanism
+     * @param key handle f the signature key
+     * @see NC#SignRecoverInit(NativeProvider, long, CKM, long)
+     * @see NativeProvider#C_SignRecoverInit(long, CKM, long)
+     */
+    public void SignRecoverInit(long session, CKM mechanism, long key) {
+        NCE.SignRecoverInit(nativeProvider, session, mechanism, key);
+    }
+
+    /**
+     * Signs data in a single operation, where the data can be recovered from the signature.
+     * @param session the session's handle
+     * @param data the data to sign
+     * @param signature gets the signature
+     * @param signatureLen gets signature length
+     * @see NC#SignRecover(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_SignRecover(long, byte[], long, byte[], LongRef)
+     */
+    public void SignRecover(long session, byte[] data, byte[] signature, LongRef signatureLen) {
+        NCE.SignRecover(nativeProvider, session, data, signature, signatureLen);
+    }
+
+    /**
+     * Signs data in a single operation, where the data can be recovered from the signature.
+     * @param session the session's handle
+     * @param data the data to sign
+     * @return signature
+     * @see NC#SignRecover(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_SignRecover(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] SignRecover(long session, byte[] data) {
+        return NCE.SignRecover(nativeProvider, session, data);
+    }
+
+    /**
+     * Signs data in a single operation, where the data can be recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the signature mechanism
+     * @param key handle f the signature key
+     * @param data the data to sign
+     * @return signature
+     * @see NC#SignRecover(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_SignRecover(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] SignRecover(long session, CKM mechanism, long key, byte[] data) {
+        return NCE.SignRecover(nativeProvider, session, mechanism, key, data);
+    }
+
+    /**
+     * Initialises a verification operation, where the signature is an appendix to the data,
+     * and plaintext cannot be recovered from the signature (e.g. DSA).
+     * @param session the session's handle
+     * @param mechanism the verification mechanism
+     * @param key verification key
+     * @see NC#VerifyInit(NativeProvider, long, CKM, long)
+     * @see NativeProvider#C_VerifyInit(long, CKM, long)
+     */
+    public void VerifyInit(long session, CKM mechanism, long key) {
+        NCE.VerifyInit(nativeProvider, session, mechanism, key);
+    }
+
+    /**
+     * Verifies a signature in a single-part operation, where the signature is an appendix to the data,
+     * and plaintext cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param data signed data
+     * @param signature signature
+     * @see NC#Verify(NativeProvider, long, byte[], byte[])
+     * @see NativeProvider#C_Verify(long, byte[], long, byte[], long)
+     */
+    public void Verify(long session, byte[] data, byte[] signature) {
+        NCE.Verify(nativeProvider, session, data, signature);
+    }
+
+    /**
+     * Continues a multiple-part verification operation where the signature is an appendix to the data,
+     * and plaintext cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param part signed data
+     * @see NC#VerifyUpdate(NativeProvider, long, byte[])
+     * @see NativeProvider#C_VerifyUpdate(long, byte[], long)
+     */
+    public void VerifyUpdate(long session, byte[] part) {
+        NCE.VerifyUpdate(nativeProvider, session, part);
+    }
+
+    /**
+     * Finishes a multiple-part verification operation, checking the signature.
+     * @param session the session's handle
+     * @param signature signature to verify
+     * @see NC#VerifyFinal(NativeProvider, long, byte[])
+     * @see NativeProvider#C_VerifyFinal(long, byte[], long)
+     */
+    public void VerifyFinal(long session, byte[] signature) {
+        NCE.VerifyFinal(nativeProvider, session, signature);
+    }
+
+    /**
+     * Verifies a signature in a single-part operation, where the signature is an appendix to the data,
+     * and plaintext cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the verification mechanism
+     * @param key verification key
+     * @param data signed data
+     * @param signature signature
+     * @see NC#Verify(NativeProvider, long, byte[], byte[])
+     * @see NativeProvider#C_Verify(long, byte[], long, byte[], long)
+     */
+    public void Verify(long session, CKM mechanism, long key, byte[] data, byte[] signature) {
+        NCE.Verify(nativeProvider, session, mechanism, key, data, signature);
+    }
+
+    /**
+     * Initialises a signature verification operation, where the data is recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the verification mechanism
+     * @param key verification key
+     * @see NC#VerifyRecoverInit(NativeProvider, long, CKM, long)
+     * @see NativeProvider#C_VerifyRecoverInit(long, CKM, long)
+     */
+    public void VerifyRecoverInit(long session, CKM mechanism, long key) {
+        NCE.VerifyRecoverInit(nativeProvider, session, mechanism, key);
+    }
+
+    /**
+     * Verifies a signature in a single-part operation, where the data is recovered from the signature.
+     * @param session the session's handle
+     * @param signature signature to verify
+     * @param data gets signed data
+     * @param dataLen gets signed data length
+     * @see NC#VerifyRecover(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_VerifyRecover(long, byte[], long, byte[], LongRef)
+     */
+    public void VerifyRecover(long session, byte[] signature, byte[] data, LongRef dataLen) {
+        NCE.VerifyRecover(nativeProvider, session, signature, data, dataLen);
+    }
+
+    /**
+     * Verifies a signature in a single-part operation, where the data is recovered from the signature.
+     * @param session the session's handle
+     * @param signature signature to verify
+     * @return data
+     * @see NC#VerifyRecover(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_VerifyRecover(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] VerifyRecover(long session, byte[] signature) {
+        return NCE.VerifyRecover(nativeProvider, session, signature);
+    }
+
+    /**
+     * Verifies a signature in a single-part operation, where the data is recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the verification mechanism
+     * @param key verification key
+     * @param signature signature to verify
+     * @return data
+     * @see NC#VerifyRecover(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_VerifyRecover(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] VerifyRecover(long session, CKM mechanism, long key, byte[] signature) {
+        return NCE.VerifyRecover(nativeProvider, session, mechanism, key, signature);
+    }
+
+    /**
+     * Continues a multiple-part digesting and encryption operation.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @param encryptedPart gets ciphertext
+     * @param encryptedPartLen get c-text length
+     * @see NC#DigestEncryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_DigestEncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public void DigestEncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
+        NCE.DigestEncryptUpdate(nativeProvider, session, part, encryptedPart, encryptedPartLen);
+    }
+
+    /**
+     * Continues a multiple-part digesting and encryption operation.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @return encrypted part
+     * @see NC#DigestEncryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_DigestEncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] DigestEncryptUpdate(long session, byte[] part) {
+        return NCE.DigestEncryptUpdate(nativeProvider, session, part);
+    }
+
+    /**
+     * Continues a multiple-part decryption and digesting operation.
+     * @param session the session's handle
+     * @param encryptedPart ciphertext
+     * @param part gets plaintext
+     * @param partLen gets plaintext length
+     * @see NC#DigestUpdate(NativeProvider, long, byte[])
+     * @see NativeProvider#C_DigestUpdate(long, byte[], long)
+     */
+    public void DecryptDigestUpdate(long session, byte[] encryptedPart, byte[] part, LongRef partLen) {
+        NCE.DecryptDigestUpdate(nativeProvider, session, encryptedPart, part, partLen);
+    }
+
+    /**
+     * Continues a multiple-part decryption and digesting operation.
+     * @param session the session's handle
+     * @param encryptedPart ciphertext
+     * @return plaintext
+     * @see NC#DecryptDigestUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_DecryptDigestUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] DecryptDigestUpdate(long session, byte[] encryptedPart) {
+        return NCE.DecryptDigestUpdate(nativeProvider, session, encryptedPart);
+    }
+
+    /**
+     * Continues a multiple-part signing and encryption operation.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @param encryptedPart gets ciphertext
+     * @param encryptedPartLen gets c-text length
+     * @see NC#SignEncryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_SignEncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public void SignEncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
+        NCE.SignEncryptUpdate(nativeProvider, session, part, encryptedPart, encryptedPartLen);
+    }
+
+    /**
+     * Continues a multiple-part signing and encryption operation.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @return encrypted part
+     * @see NC#SignEncryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_SignEncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] SignEncryptUpdate(long session, byte[] part) {
+        return NCE.SignEncryptUpdate(nativeProvider, session, part);
+    }
+
+    /**
+     * Continues a multiple-part decryption and verify operation.
+     * @param session the session's handle
+     * @param encryptedPart ciphertext
+     * @param part gets plaintext
+     * @param partLen gets p-text length
+     * @see NC#DecryptVerifyUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_DecryptVerifyUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public void DecryptVerifyUpdate(long session, byte[] encryptedPart, byte[] part, LongRef partLen) {
+        NCE.DecryptVerifyUpdate(nativeProvider, session, encryptedPart, part, partLen);
+    }
+
+    /**
+     * Continues a multiple-part decryption and verify operation.
+     * @param session the session's handle
+     * @param encryptedPart ciphertext
+     * @return plaintext
+     * @see NC#DecryptVerifyUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_DecryptVerifyUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public byte[] DecryptVerifyUpdate(long session, byte[] encryptedPart) {
+        return NCE.DecryptVerifyUpdate(nativeProvider, session, encryptedPart);
+    }
+
+    /**
+     * Generates a secret key, creating a new key.
+     * @param session the session's handle
+     * @param mechanism key generation mechanism
+     * @param templ template for the new key
+     * @param key gets handle of new key
+     * @see NC#GenerateKey(NativeProvider, long, CKM, CKA[], LongRef)
+     * @see NativeProvider#C_GenerateKey(long, CKM, CKA[], long, LongRef)
+     */
+    public void GenerateKey(long session, CKM mechanism, CKA[] templ, LongRef key) {
+        NCE.GenerateKey(nativeProvider, session, mechanism, templ, key);
+    }
+
+    /**
+     * Generates a secret key, creating a new key.
+     * @param session the session's handle
+     * @param mechanism key generation mechanism
+     * @param templ template for the new key
+     * @return key handle
+     * @see NC#GenerateKey(NativeProvider, long, CKM, CKA[], LongRef)
+     * @see NativeProvider#C_GenerateKey(long, CKM, CKA[], long, LongRef)
+     */
+    public long GenerateKey(long session, CKM mechanism, CKA... templ) {
+        return NCE.GenerateKey(nativeProvider, session, mechanism, templ);
+    }
+
+    /**
+     * Generates a public-key / private-key pair, create new key objects.
+     * @param session the session's handle
+     * @param mechanism key generation mechanism
+     * @param publicKeyTemplate template for the new public key
+     * @param privateKeyTemplate template for the new private key
+     * @param publicKey gets handle of new public key
+     * @param privateKey gets handle of new private key
+     * @see NC#GenerateKeyPair(NativeProvider, long, CKM, CKA[], CKA[], LongRef, LongRef)
+     * @see NativeProvider#C_GenerateKeyPair(long, CKM, CKA[], long, CKA[], long, LongRef, LongRef)
+     */
+    public void GenerateKeyPair(long session, CKM mechanism, CKA[] publicKeyTemplate, CKA[] privateKeyTemplate,
+                                       LongRef publicKey, LongRef privateKey) {
+        NCE.GenerateKeyPair(nativeProvider, session, mechanism, publicKeyTemplate, privateKeyTemplate, publicKey, privateKey);
+    }
+
+    /**
+     * Wraps (encrypts) a key.
+     * @param session the session's handle
+     * @param mechanism the wrapping mechanism
+     * @param wrappingKey wrapping key
+     * @param key key to be wrapped
+     * @param wrappedKey gets wrapped key
+     * @param wrappedKeyLen gets wrapped key length
+     * @see NC#WrapKey(NativeProvider, long, CKM, long, long, byte[], LongRef)
+     * @see NativeProvider#C_WrapKey(long, CKM, long, long, byte[], LongRef)
+     */
+    public void WrapKey(long session, CKM mechanism, long wrappingKey, long key, byte[] wrappedKey, LongRef wrappedKeyLen) {
+        NCE.WrapKey(nativeProvider, session, mechanism, wrappingKey, key, wrappedKey, wrappedKeyLen);
+    }
+
+    /**
+     * Wraps (encrypts) a key.
+     * @param session the session's handle
+     * @param mechanism the wrapping mechanism
+     * @param wrappingKey wrapping key
+     * @param key key to be wrapped
+     * @return wrapped key
+     * @see NC#WrapKey(NativeProvider, long, CKM, long, long, byte[], LongRef)
+     * @see NativeProvider#C_WrapKey(long, CKM, long, long, byte[], LongRef)
+     */
+    public byte[] WrapKey(long session, CKM mechanism, long wrappingKey, long key) {
+        return NCE.WrapKey(nativeProvider, session, mechanism, wrappingKey, key);
+    }
+
+    /**
+     * Unwraps (decrypts) a wrapped key, creating a new key object.
+     * @param session the session's handle
+     * @param mechanism unwrapping mechanism
+     * @param unwrappingKey unwrapping key
+     * @param wrappedKey the wrapped key
+     * @param templ new key template
+     * @param key gets new handle
+     * @see NC#UnwrapKey(NativeProvider, long, CKM, long, byte[], CKA[], LongRef)
+     * @see NativeProvider#C_UnwrapKey(long, CKM, long, byte[], long, CKA[], long, LongRef)
+     */
+    public void UnwrapKey(long session, CKM mechanism, long unwrappingKey, byte[] wrappedKey, CKA[] templ, LongRef key) {
+        NCE.UnwrapKey(nativeProvider, session, mechanism, unwrappingKey, wrappedKey, templ, key);
+    }
+
+    /**
+     * Unwraps (decrypts) a wrapped key, creating a new key object.
+     * @param session the session's handle
+     * @param mechanism unwrapping mechanism
+     * @param unwrappingKey unwrapping key
+     * @param wrappedKey the wrapped key
+     * @param templ new key template
+     * @return key handle
+     * @see NC#UnwrapKey(NativeProvider, long, CKM, long, byte[], CKA[], LongRef)
+     * @see NativeProvider#C_UnwrapKey(long, CKM, long, byte[], long, CKA[], long, LongRef)
+     */
+    public long UnwrapKey(long session, CKM mechanism, long unwrappingKey, byte[] wrappedKey, CKA... templ) {
+        return NCE.UnwrapKey(nativeProvider, session, mechanism, unwrappingKey, wrappedKey, templ);
+    }
+
+    /**
+     * Derives a key from a base key, creating a new key object.
+     * @param session the session's handle
+     * @param mechanism key derivation mechanism
+     * @param baseKey base key
+     * @param templ new key template
+     * @param key ges new handle
+     * @see NC#DeriveKey(NativeProvider, long, CKM, long, CKA[], LongRef)
+     * @see NativeProvider#C_DeriveKey(long, CKM, long, CKA[], long, LongRef)
+     */
+    public void DeriveKey(long session, CKM mechanism, long baseKey, CKA[] templ, LongRef key) {
+        NCE.DeriveKey(nativeProvider, session, mechanism, baseKey, templ, key);
+    }
+
+    /**
+     * Derives a key from a base key, creating a new key object.
+     * @param session the session's handle
+     * @param mechanism key derivation mechanism
+     * @param baseKey base key
+     * @param templ new key template
+     * @return new handle
+     * @see NC#DeriveKey(NativeProvider, long, CKM, long, CKA[], LongRef)
+     * @see NativeProvider#C_DeriveKey(long, CKM, long, CKA[], long, LongRef)
+     */
+    public long DeriveKey(long session, CKM mechanism, long baseKey, CKA... templ) {
+        return NCE.DeriveKey(nativeProvider, session, mechanism, baseKey, templ);
+    }
+
+    /**
+     * Mixes additional seed material into the token's random number generator.
+     * @param session the session's handle
+     * @param seed the seed material
+     * @see NC#SeedRandom(NativeProvider, long, byte[])
+     * @see NativeProvider#C_SeedRandom(long, byte[], long)
+     */
+    public void SeedRandom(long session, byte[] seed) {
+        NCE.SeedRandom(nativeProvider, session, seed);
+    }
+
+    /**
+     * Generates random or pseudo-random data.
+     * @param session the session's handle
+     * @param randomData receives the random data
+     * @see NC#GenerateRandom(NativeProvider, long, byte[])
+     * @see NativeProvider#C_GenerateRandom(long, byte[], long)
+     */
+    public void GenerateRandom(long session, byte[] randomData) {
+        NCE.GenerateRandom(nativeProvider, session, randomData);
+    }
+
+    /**
+     * Generates random or pseudo-random data.
+     * @param session the session's handle
+     * @param randomLen number of bytes of random to generate
+     * @return random
+     * @see NC#GenerateRandom(NativeProvider, long, byte[])
+     * @see NativeProvider#C_GenerateRandom(long, byte[], long)
+     */
+    public byte[] GenerateRandom(long session, int randomLen) {
+        return NCE.GenerateRandom(nativeProvider, session, randomLen);
+    }
+
+    /**
+     * In previous versions of Cryptoki, C_GetFunctionStatus obtained the status of a function running in parallel
+     * with an application. Now, however, C_GetFunctionStatus is a legacy function which should simply return
+     * the value CKR_FUNCTION_NOT_PARALLEL.
+     * @param session the session's handle
+     * @see NC#GetFunctionStatus(NativeProvider, long)
+     * @see NativeProvider#C_GetFunctionStatus(long)
+     */
+    public void GetFunctionStatus(long session) {
+        NCE.GetFunctionStatus(nativeProvider, session);
+    }
+
+    /**
+     * In previous versions of Cryptoki, C_CancelFunction cancelled a function running in parallel with an application.
+     * Now, however, C_CancelFunction is a legacy function which should simply return the value
+     * CKR_FUNCTION_NOT_PARALLEL.
+     * @param session the session's handle
+     * @see NC#GetFunctionStatus(NativeProvider, long)
+     * @see NativeProvider#C_GetFunctionStatus(long)
+     */
+    public void CancelFunction(long session) {
+        NCE.CancelFunction(nativeProvider, session);
+    }
+}

--- a/src/main/java/org/pkcs11/jacknji11/CKA.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKA.java
@@ -196,7 +196,7 @@ public class CKA {
     public static final long VENDOR_PTK_ENUM_ATTRIBUTE = 0x0000ffff;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CKA.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CKA.class);
 
     /**
      * Convert long constant value to name.
@@ -206,7 +206,7 @@ public class CKA {
      * @return name
      */
     public static final String L2S(long cka) {
-        return C.l2s(L2S, CKA.class.getSimpleName(), cka);
+        return NC.l2s(L2S, CKA.class.getSimpleName(), cka);
     }
 
     public long type;
@@ -263,7 +263,7 @@ public class CKA {
 
     /** When reading values from PKCS#11 you often send a buffer, with a specific length
      * where the buffer may be lager than the value returned. The actual length of the value returned
-     * is then put by the HSM in ulValueLen. Before returning to Java, therefore make sure 
+     * is then put by the HSM in ulValueLen. Before returning to Java, therefore make sure
      * the returned pValue hodls the actual bytes and not extra (empty) data.
      */
     private byte[] getValueInternal() {
@@ -435,7 +435,7 @@ public class CKA {
         dump(sb);
         return sb.toString();
     }
-    
+
     @Override
     public int hashCode() {
         final int prime = 31;

--- a/src/main/java/org/pkcs11/jacknji11/CKC.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKC.java
@@ -35,11 +35,11 @@ public class CKC {
     public static final long CKC_VENDOR_DEFINED  = 0x80000000;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CKS.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CKS.class);
     /**
      * Convert long constant value to name.
      * @param cks value
      * @return name
      */
-    public static final String L2S(long cks) { return C.l2s(L2S, CKS.class.getSimpleName(), cks); }
+    public static final String L2S(long cks) { return NC.l2s(L2S, CKS.class.getSimpleName(), cks); }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CKD.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKD.java
@@ -34,11 +34,11 @@ public class CKD {
     public static final long SHA1_KDF_CONCATENATE    = 0x00000004;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CKD.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CKD.class);
     /**
      * Convert long constant value to name.
      * @param ckd value
      * @return name
      */
-    public static final String L2S(long ckd) { return C.l2s(L2S, CKD.class.getSimpleName(), ckd); }
+    public static final String L2S(long ckd) { return NC.l2s(L2S, CKD.class.getSimpleName(), ckd); }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CKG.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKG.java
@@ -35,11 +35,11 @@ public class CKG {
     public static final long MGF1_SHA224 = 0x00000005;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CKG.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CKG.class);
     /**
      * Convert long constant value to name.
      * @param ckg value
      * @return name
      */
-    public static final String L2S(long ckg) { return C.l2s(L2S, CKG.class.getSimpleName(), ckg); }
+    public static final String L2S(long ckg) { return NC.l2s(L2S, CKG.class.getSimpleName(), ckg); }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CKH.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKH.java
@@ -34,11 +34,11 @@ public class CKH {
     public static final long VENDOR_DEFINED      = 0x80000000;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CKH.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CKH.class);
     /**
      * Convert long constant value to name.
      * @param ckh value
      * @return name
      */
-    public static final String L2S(long ckh) { return C.l2s(L2S, CKH.class.getSimpleName(), ckh); }
+    public static final String L2S(long ckh) { return NC.l2s(L2S, CKH.class.getSimpleName(), ckh); }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CKK.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKK.java
@@ -77,11 +77,11 @@ public class CKK {
     public static final long VENDOR_PTK_SEED            = 0x80000203L;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CKK.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CKK.class);
     /**
      * Convert long constant value to name.
      * @param ckk value
      * @return name
      */
-    public static final String L2S(long ckk) { return C.l2s(L2S, CKK.class.getSimpleName(), ckk); }
+    public static final String L2S(long ckk) { return NC.l2s(L2S, CKK.class.getSimpleName(), ckk); }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CKM.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKM.java
@@ -347,13 +347,13 @@ public class CKM {
     public static final long VENDOR_PTK_ECIES            = 0x80000a00L;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CKM.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CKM.class);
     /**
      * Convert long constant value to name.
      * @param ckm value
      * @return name
      */
-    public static final String L2S(long ckm) { return C.l2s(L2S, CKM.class.getSimpleName(), ckm); }
+    public static final String L2S(long ckm) { return NC.l2s(L2S, CKM.class.getSimpleName(), ckm); }
 
     /** Default params for some mechanisms. */
     public static final Map<Long, byte[]> DEFAULT_PARAMS = new HashMap<Long, byte[]>();
@@ -396,7 +396,7 @@ public class CKM {
         ulParameterLen = paramSize;
     }
 
-    public CKM(long mechanism, byte[] param) {    
+    public CKM(long mechanism, byte[] param) {
         this.mechanism = mechanism;
         int len = (param != null) ? param.length : 0;
         if (len > 0) {
@@ -417,7 +417,7 @@ public class CKM {
     /** @return string */
     public String toString() {
         return String.format("mechanism=0x%08x{%s} paramLen=%d param=%s",
-            mechanism, L2S(mechanism), bParameter != null ? bParameter.length : 0, 
+            mechanism, L2S(mechanism), bParameter != null ? bParameter.length : 0,
                     Hex.b2s(bParameter));
     }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CKO.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKO.java
@@ -48,11 +48,11 @@ public class CKO {
     public static final long VENDOR_PTK_FM                   = 0x8000020c;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CKO.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CKO.class);
     /**
      * Convert long constant value to name.
      * @param cko value
      * @return name
      */
-    public static final String L2S(long cko) { return C.l2s(L2S, CKO.class.getSimpleName(), cko); }
+    public static final String L2S(long cko) { return NC.l2s(L2S, CKO.class.getSimpleName(), cko); }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CKP.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKP.java
@@ -31,11 +31,11 @@ public class CKP {
     public static final long CKP_PKCS5_PBKD2_HMAC_SHA1 = 0x00000001;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CKP.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CKP.class);
     /**
      * Convert long constant value to name.
      * @param ckp value
      * @return name
      */
-    public static final String L2S(long ckp) { return C.l2s(L2S, CKP.class.getSimpleName(), ckp); }
+    public static final String L2S(long ckp) { return NC.l2s(L2S, CKP.class.getSimpleName(), ckp); }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CKR.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKR.java
@@ -183,11 +183,11 @@ public class CKR {
     public static final long VENDOR_PTK_WLD_LOGIN_CACHE_INCONSISTENT = 0x80002010;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CKR.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CKR.class);
     /**
      * Convert long constant value to name.
      * @param ckr value
      * @return name
      */
-    public static final String L2S(long ckr) { return C.l2s(L2S, CKR.class.getSimpleName(), ckr); }
+    public static final String L2S(long ckr) { return NC.l2s(L2S, CKR.class.getSimpleName(), ckr); }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CKS.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKS.java
@@ -35,11 +35,11 @@ public class CKS {
     public static final long RW_SO_FUNCTIONS = 4;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CKS.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CKS.class);
     /**
      * Convert long constant value to name.
      * @param cks value
      * @return name
      */
-    public static final String L2S(long cks) { return C.l2s(L2S, CKS.class.getSimpleName(), cks); }
+    public static final String L2S(long cks) { return NC.l2s(L2S, CKS.class.getSimpleName(), cks); }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CKU.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKU.java
@@ -33,11 +33,11 @@ public class CKU {
     public static final long USER    = 0x00000001;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CKU.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CKU.class);
     /**
      * Convert long constant value to name.
      * @param cku value
      * @return name
      */
-    public static final String L2S(long cku) { return C.l2s(L2S, CKU.class.getSimpleName(), cku); }
+    public static final String L2S(long cku) { return NC.l2s(L2S, CKU.class.getSimpleName(), cku); }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CKZ.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKZ.java
@@ -31,11 +31,11 @@ public class CKZ {
     public static final long DATA_SPECIFIED = 0x00000001;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CKZ.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CKZ.class);
     /**
      * Convert long constant value to name.
      * @param ckz value
      * @return name
      */
-    public static final String L2S(long ckz) { return C.l2s(L2S, CKZ.class.getSimpleName(), ckz); }
+    public static final String L2S(long ckz) { return NC.l2s(L2S, CKZ.class.getSimpleName(), ckz); }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CK_C_INITIALIZE_ARGS.java
+++ b/src/main/java/org/pkcs11/jacknji11/CK_C_INITIALIZE_ARGS.java
@@ -38,19 +38,19 @@ public class CK_C_INITIALIZE_ARGS {
     public static final long CKF_OS_LOCKING_OK = 0x00000002;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CK_C_INITIALIZE_ARGS.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CK_C_INITIALIZE_ARGS.class);
     /**
      * Convert long constant value to name.
      * @param ckf value
      * @return name
      */
-    public static final String L2S(long ckf) { return C.l2s(L2S, "CKF", ckf); }
+    public static final String L2S(long ckf) { return NC.l2s(L2S, "CKF", ckf); }
     /**
      * Convert flags to string.
      * @param flags flags
      * @return string format
      */
-    public static String f2s(long flags) { return C.f2s(L2S, flags); }
+    public static String f2s(long flags) { return NC.f2s(L2S, flags); }
 
 
     public CK_CREATEMUTEX createMutex;
@@ -77,7 +77,7 @@ public class CK_C_INITIALIZE_ARGS {
         this.unlockMutex = unlockMutex;
         this.flags = flags;
     }
-    
+
     /** @return True, if the provided flag is set */
     public boolean isFlagSet(long CKF_FLAG) {
         return (flags & CKF_FLAG) != 0L;

--- a/src/main/java/org/pkcs11/jacknji11/CK_INFO.java
+++ b/src/main/java/org/pkcs11/jacknji11/CK_INFO.java
@@ -30,19 +30,19 @@ import java.util.Map;
 public class CK_INFO {
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CK_INFO.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CK_INFO.class);
     /**
      * Convert long constant value to name.
      * @param ckf value
      * @return name
      */
-    public static final String L2S(long ckf) { return C.l2s(L2S, "CKF", ckf); }
+    public static final String L2S(long ckf) { return NC.l2s(L2S, "CKF", ckf); }
     /**
      * Convert flags to string.
      * @param flags flags
      * @return string format
      */
-    public static String f2s(long flags) { return C.f2s(L2S, flags); }
+    public static String f2s(long flags) { return NC.f2s(L2S, flags); }
 
     public CK_VERSION cryptokiVersion = new CK_VERSION();
     public byte[] manufacturerID = new byte[32];

--- a/src/main/java/org/pkcs11/jacknji11/CK_MECHANISM_INFO.java
+++ b/src/main/java/org/pkcs11/jacknji11/CK_MECHANISM_INFO.java
@@ -51,19 +51,19 @@ public class CK_MECHANISM_INFO {
 
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CK_MECHANISM_INFO.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CK_MECHANISM_INFO.class);
     /**
      * Convert long constant value to name.
      * @param ckf value
      * @return name
      */
-    public static final String I2S(long ckf) { return C.l2s(L2S, "CKF", ckf); }
+    public static final String I2S(long ckf) { return NC.l2s(L2S, "CKF", ckf); }
     /**
      * Convert flags to string.
      * @param flags flags
      * @return string format
      */
-    public static String f2s(long flags) { return C.f2s(L2S, flags); }
+    public static String f2s(long flags) { return NC.f2s(L2S, flags); }
 
 
     public long ulMinKeySize;
@@ -74,7 +74,7 @@ public class CK_MECHANISM_INFO {
     public boolean isFlagSet(long CKF_FLAG) {
         return (flags & CKF_FLAG) != 0L;
     }
-    
+
     /** @return string */
     public String toString() {
         return String.format("(\n  minKeySize=%d\n  maxKeySize=%d\n  flags=0x%08x{%s}\n)",

--- a/src/main/java/org/pkcs11/jacknji11/CK_SESSION_INFO.java
+++ b/src/main/java/org/pkcs11/jacknji11/CK_SESSION_INFO.java
@@ -33,19 +33,19 @@ public class CK_SESSION_INFO {
     public static final long CKF_SERIAL_SESSION = 0x00000004;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CK_SESSION_INFO.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CK_SESSION_INFO.class);
     /**
      * Convert long constant value to name.
      * @param ckf value
      * @return name
      */
-    public static final String I2S(long ckf) { return C.l2s(L2S, "CKF", ckf); }
+    public static final String I2S(long ckf) { return NC.l2s(L2S, "CKF", ckf); }
     /**
      * Convert flags to string.
      * @param flags flags
      * @return string format
      */
-    public static String f2s(long flags) { return C.f2s(L2S, flags); }
+    public static String f2s(long flags) { return NC.f2s(L2S, flags); }
 
     public long slotID;
     public long state;
@@ -56,7 +56,7 @@ public class CK_SESSION_INFO {
     public boolean isFlagSet(long CKF_FLAG) {
         return (flags & CKF_FLAG) != 0L;
     }
-    
+
     /** @return string */
     public String toString() {
         return String.format("(\n  slotID=0x%08x\n  state=0x%08x{%s}\n  flags=0x%08x{%s}\n  deviceError=%d\n)",

--- a/src/main/java/org/pkcs11/jacknji11/CK_SLOT_INFO.java
+++ b/src/main/java/org/pkcs11/jacknji11/CK_SLOT_INFO.java
@@ -34,19 +34,19 @@ public class CK_SLOT_INFO {
     public static final long CKF_HW_SLOT          = 0x00000004;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CK_SLOT_INFO.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CK_SLOT_INFO.class);
     /**
      * Convert long constant value to name.
      * @param ckf value
      * @return name
      */
-    public static final String L2S(long ckf) { return C.l2s(L2S, "CKF", ckf); }
+    public static final String L2S(long ckf) { return NC.l2s(L2S, "CKF", ckf); }
     /**
      * Convert flags to string.
      * @param flags flags
      * @return string format
      */
-    public static String f2s(long flags) { return C.f2s(L2S, flags); }
+    public static String f2s(long flags) { return NC.f2s(L2S, flags); }
 
     public byte[] slotDescription = new byte[64];
     public byte[] manufacturerID = new byte[32];
@@ -58,7 +58,7 @@ public class CK_SLOT_INFO {
     public boolean isFlagSet(long CKF_FLAG) {
         return (flags & CKF_FLAG) != 0L;
     }
-    
+
     /** @return string */
     public String toString() {
         return String.format("(\n  slotDescription=%s\n  manufacturerID=%s\n  flags=0x%08x{%s}\n  hardwareVersion=%d.%d\n  firmwareVersion=%d.%d\n)",

--- a/src/main/java/org/pkcs11/jacknji11/CK_TOKEN_INFO.java
+++ b/src/main/java/org/pkcs11/jacknji11/CK_TOKEN_INFO.java
@@ -48,19 +48,19 @@ public class CK_TOKEN_INFO {
     public static final long CKF_SO_PIN_TO_BE_CHANGED     =0x00800000;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CK_TOKEN_INFO.class);
+    private static final Map<Long, String> L2S = NC.createL2SMap(CK_TOKEN_INFO.class);
     /**
      * Convert long constant value to name.
      * @param ckf value
      * @return name
      */
-    public static final String L2S(long ckf) { return C.l2s(L2S, "CKF", ckf); }
+    public static final String L2S(long ckf) { return NC.l2s(L2S, "CKF", ckf); }
     /**
      * Convert flags to string.
      * @param flags flags
      * @return string format
      */
-    public static String f2s(long flags) { return C.f2s(L2S, flags); }
+    public static String f2s(long flags) { return NC.f2s(L2S, flags); }
 
     public byte[] label = new byte[32];
     public byte[] manufacturerID = new byte[32];
@@ -85,7 +85,7 @@ public class CK_TOKEN_INFO {
     public boolean isFlagSet(long CKF_FLAG) {
         return (flags & CKF_FLAG) != 0L;
     }
-    
+
     /** @return string */
     public String toString() {
         return String.format("(\n  label=%s\n  manufacturerID=%s\n  model=%s\n  serialNumber=%s\n  flags=0x%08x{%s}" +

--- a/src/main/java/org/pkcs11/jacknji11/Ci.java
+++ b/src/main/java/org/pkcs11/jacknji11/Ci.java
@@ -1,0 +1,899 @@
+/*
+ * Copyright 2010-2011 Joel Hockey (joel.hockey@gmail.com). All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.pkcs11.jacknji11;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pkcs11.jacknji11.jna.JNA;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Low-level java interface that maps to {@link NativeProvider} cryptoki calls.
+ *
+ * jacknji11 provides 3 interfaces for calling cryptoki functions.
+ * <ol>
+ * <li>{@link NativeProvider} provides the lowest level
+ * direct mapping to the <code>'C_*'</code> functions.  There is little
+ * reason why you would ever want to invoke it directly, but you can.
+ * <li>{@link Ci} provides the exact same functions
+ * as {@link NativeProvider} by calling through to the
+ * corresponding native method.  The <code>'C_'</code> at the start of the
+ * function name is removed since the <code>'NC.'</code> when you call the
+ * static methods of this class looks similar.  In addition to calling
+ * the native methods, {@link Ci} provides logging
+ * through apache commons logging.  You can use this if you require fine-grain
+ * control over something such as checking
+ * {@link CKR} return codes.
+ * <li>{@link CE} (<b>C</b>ryptoki
+ * with <b>E</b>xceptions) provides the most user-friendly interface
+ * and is the preferred interface to use.  It calls
+ * related function(s) in {@link Ci},
+ * and converts any non-zero return values into a
+ * {@link CKRException}.  It automatically resizes
+ * arrays and other helpful things.
+ * </ol>
+ *
+ * @author Joel Hockey (joel.hockey@gmail.com)
+ */
+public class Ci {
+    private final NativeProvider nativeProvider;
+
+    public Ci(NativeProvider nativeProvider) {
+        this.nativeProvider = nativeProvider;
+    }
+
+    public Ci() {
+        this(new JNA(NC.getLibraryName()));
+    }
+
+    /**
+     * Initialise Cryptoki with null mutexes, and CKF_OS_LOCKING_OK flag set.
+     * @see NativeProvider#C_Initialize(CK_C_INITIALIZE_ARGS)
+     * @return {@link CKR} return code
+     */
+    public long Initialize() {
+        return NC.Initialize(nativeProvider);
+    }
+
+    /**
+     * Initialise Cryptoki with supplied args.
+     * @see NativeProvider#C_Initialize(CK_C_INITIALIZE_ARGS)
+     * @return {@link CKR} return code
+     */
+    public long Initialize(CK_C_INITIALIZE_ARGS pInitArgs) {
+        return NC.Initialize(nativeProvider, pInitArgs);
+    }
+
+    /**
+     * Called to indicate that an application is finished with the Cryptoki library.
+     * @see NativeProvider#C_Finalize(NativePointer)
+     * @return {@link CKR} return code
+     */
+    public long Finalize() {
+        return NC.Finalize(nativeProvider);
+    }
+
+    /**
+     * Returns general information about Cryptoki.
+     * @param info location that receives information
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetInfo(CK_INFO)
+     */
+    public long GetInfo(CK_INFO info) {
+        return NC.GetInfo(nativeProvider, info);
+    }
+
+    /**
+     * Obtains a list of slots in the system.
+     * @param tokenPresent only slots with tokens?
+     * @param slotList receives array of slot IDs
+     * @param count receives the number of slots
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef)
+     */
+    public long GetSlotList(boolean tokenPresent, long[] slotList, LongRef count) {
+        return NC.GetSlotList(nativeProvider, tokenPresent, slotList, count);
+    }
+
+    /**
+     * Obtains information about a particular slot in the system.
+     * @param slotID the ID of the slot
+     * @param info receives the slot information
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetSlotInfo(long, CK_SLOT_INFO)
+     */
+    public long GetSlotInfo(long slotID, CK_SLOT_INFO info) {
+        return NC.GetSlotInfo(nativeProvider, slotID, info);
+    }
+
+    /**
+     * Obtains information about a particular token in the system.
+     * @param slotID ID of the token's slot
+     * @param info receives the token information
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetTokenInfo(long, CK_TOKEN_INFO)
+     */
+    public long GetTokenInfo(long slotID, CK_TOKEN_INFO info) {
+        return NC.GetTokenInfo(nativeProvider, slotID, info);
+    }
+
+    /**
+     * Waits for a slot event (token insertion, removal, etc.) to occur.
+     * @param flags blocking/nonblocking flag
+     * @param slot location that receives the slot ID
+     * @param reserved reserved.  Should be null
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_WaitForSlotEvent(long, LongRef, NativePointer)
+     */
+    public long WaitForSlotEvent(long flags, LongRef slot, NativePointer reserved) {
+        return NC.WaitForSlotEvent(nativeProvider, flags, slot, reserved);
+    }
+
+    /**
+     * Obtains a list of mechanism types supported by a token.
+     * @param slotID ID of token's slot
+     * @param mechanismList gets mechanism array
+     * @param count gets # of mechanisms
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetMechanismList(long, long[], LongRef)
+     */
+    public long GetMechanismList(long slotID, long[] mechanismList, LongRef count) {
+        return NC.GetMechanismList(nativeProvider, slotID, mechanismList, count);
+    }
+
+    /**
+     * Obtains information about a particular mechanism possibly supported by a token.
+     * @param slotID ID of the token's slot
+     * @param type {@link CKM} type of mechanism
+     * @param info receives mechanism info
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetMechanismInfo(long, long, CK_MECHANISM_INFO)
+     */
+    public long GetMechanismInfo(long slotID, long type, CK_MECHANISM_INFO info) {
+        return NC.GetMechanismInfo(nativeProvider, slotID, type, info);
+    }
+
+    /**
+     * Initialises a token.  Pad or truncate label if required.
+     * @param slotID ID of the token's slot
+     * @param pin the SO's initial PIN
+     * @param label 32-byte token label (space padded).  If not 32 bytes, then
+     * it will be padded or truncated as required
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_InitToken(long, byte[], long, byte[])
+     */
+    public long InitToken(long slotID, byte[] pin, byte[] label) {
+        return NC.InitToken(nativeProvider, slotID, pin, label);
+    }
+
+    /**
+     * Initialise normal user with PIN.
+     * @param session the session's handle
+     * @param pin the normal user's PIN
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_InitPIN(long, byte[], long)
+     */
+    public long InitPIN(long session, byte[] pin) {
+        return NC.InitPIN(nativeProvider, session, pin);
+    }
+
+    /**
+     * Change PIN.
+     * @param session the session's handle
+     * @param oldPin old PIN
+     * @param newPin new PIN
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SetPIN(long, byte[], long, byte[], long)
+     */
+    public long SetPIN(long session, byte[] oldPin, byte[] newPin) {
+        return NC.SetPIN(nativeProvider, session, oldPin, newPin);
+    }
+
+    /**
+     * Opens a session between an application and a token.
+     * @param slotID the slot's ID
+     * @param flags from {@link CK_SESSION_INFO}
+     * @param application passed to callback (ok to leave it null)
+     * @param notify callback function (ok to leave it null)
+     * @param session gets session handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
+     */
+    public long OpenSession(long slotID, long flags, NativePointer application, CK_NOTIFY notify, LongRef session) {
+        return NC.OpenSession(nativeProvider, slotID, flags, application, notify, session);
+    }
+
+    /**
+     * Closes a session between an application and a token.
+     * @param session the session's handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_CloseSession(long)
+     */
+    public long CloseSession(long session) {
+        return NC.CloseSession(nativeProvider, session);
+    }
+
+    /**
+     * Closes all sessions with a token.
+     * @param slotID the token's slot
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_CloseAllSessions(long)
+     */
+    public long CloseAllSessions(long slotID) {
+        return NC.CloseAllSessions(nativeProvider, slotID);
+    }
+
+    /**
+     * Obtains information about the session.
+     * @param session the session's handle
+     * @param info receives session info
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetSessionInfo(long, CK_SESSION_INFO)
+     */
+    public long GetSessionInfo(long session, CK_SESSION_INFO info) {
+        return NC.GetSessionInfo(nativeProvider, session, info);
+    }
+
+    /**
+     * Obtains the state of the cryptographic operation.
+     * @param session the session's handle
+     * @param operationState gets state
+     * @param operationStateLen gets state length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetOperationState(long, byte[], LongRef)
+     */
+    public long GetOperationState(long session, byte[] operationState, LongRef operationStateLen) {
+        return NC.GetOperationState(nativeProvider, session, operationState, operationStateLen);
+    }
+
+    /**
+     * Restores the state of the cryptographic operation in a session.
+     * @param session the session's handle
+     * @param operationState holds state
+     * @param encryptionKey en/decryption key
+     * @param authenticationKey sign/verify key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SetOperationState(long, byte[], long, long, long)
+     */
+    public long SetOperationState(long session, byte[] operationState,
+            long encryptionKey, long authenticationKey) {
+        return NC.SetOperationState(nativeProvider, session, operationState, encryptionKey, authenticationKey);
+    }
+
+    /**
+     * Logs a user into a token.
+     * @param session the session's handle
+     * @param userType the user type from {@link CKU}
+     * @param pin the user's PIN
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_Login(long, long, byte[], long)
+     */
+    public long Login(long session, long userType, byte[] pin) {
+        return NC.Login(nativeProvider, session, userType, pin);
+    }
+
+    /**
+     * Logs a user out from a token.
+     * @param session the session's handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_Logout(long)
+     */
+    public long Logout(long session) {
+        return NC.Logout(nativeProvider, session);
+    }
+
+    /**
+     * Creates a new object.
+     * @param session the session's handle
+     * @param templ the objects template
+     * @param object gets new object's handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_CreateObject(long, CKA[], long, LongRef)
+     */
+    public long CreateObject(long session, CKA[] templ, LongRef object) {
+        return NC.CreateObject(nativeProvider, session, templ, object);
+    }
+
+    /**
+     * Copies an object, creating a new object for the copy.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @param templ template for new object
+     * @param newObject receives handle of copy
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_CopyObject(long, long, CKA[], long, LongRef)
+     */
+    public long CopyObject(long session, long object, CKA[] templ, LongRef newObject) {
+        return NC.CopyObject(nativeProvider, session, object, templ, newObject);
+    }
+
+    /**
+     * Destroys an object.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DestroyObject(long, long)
+     */
+    public long DestroyObject(long session, long object) {
+        return NC.DestroyObject(nativeProvider, session, object);
+    }
+
+    /**
+     * Gets the size of an object in bytes.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @param size receives the size of object
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetObjectSize(long, long, LongRef)
+     */
+    public long GetObjectSize(long session, long object, LongRef size) {
+        return NC.GetObjectSize(nativeProvider, session, object, size);
+    }
+
+    /**
+     * Obtains the value of one or more object attributes.
+     * @param session the session's handle
+     * @param object the objects's handle
+     * @param templ specifies attributes, gets values
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetAttributeValue(long, long, CKA[], long)
+     */
+    public long GetAttributeValue(long session, long object, CKA[] templ) {
+        return NC.GetAttributeValue(nativeProvider, session, object, templ);
+    }
+
+    /**
+     * Modifies the values of one or more object attributes.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @param templ specifies attributes and values
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SetAttributeValue(long, long, CKA[], long)
+     */
+    public long SetAttributeValue(long session, long object, CKA[] templ) {
+        return NC.SetAttributeValue(nativeProvider, session, object, templ);
+    }
+
+    /**
+     * Initialises a search for token and session objects that match a template.
+     * @param session the session's handle
+     * @param templ attribute values to match
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_FindObjectsInit(long, CKA[], long)
+     */
+    public long FindObjectsInit(long session, CKA[] templ) {
+        return NC.FindObjectsInit(nativeProvider, session, templ);
+    }
+
+    /**
+     * Continues a search for token and session objects that match a template,
+     * obtaining additional object handles.
+     * @param session the session's handle
+     * @param found gets object handles
+     * @param objectCount number of object handles returned
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_FindObjects(long, long[], long, LongRef)
+     */
+    public long FindObjects(long session, long[] found, LongRef objectCount) {
+        return NC.FindObjects(nativeProvider, session, found, objectCount);
+    }
+
+    /**
+     * Finishes a search for token and session objects.
+     * @param session the session's handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_FindObjectsFinal(long)
+     */
+    public long FindObjectsFinal(long session) {
+        return NC.FindObjectsFinal(nativeProvider, session);
+    }
+
+    /**
+     * Initialises an encryption operation.
+     * @param session the session's handle
+     * @param mechanism the encryption mechanism
+     * @param key handle of encryption key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_EncryptInit(long, CKM, long)
+     */
+    public long EncryptInit(long session, CKM mechanism, long key) {
+        return NC.EncryptInit(nativeProvider, session, mechanism, key);
+    }
+
+    /**
+     * Encrypts single-part data.
+     * @param session the session's handle
+     * @param data the plaintext data
+     * @param encryptedData gets ciphertext
+     * @param encryptedDataLen gets c-text size
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     */
+    public long Encrypt(long session, byte[] data, byte[] encryptedData, LongRef encryptedDataLen) {
+        return NC.Encrypt(nativeProvider, session, data, encryptedData, encryptedDataLen);
+    }
+
+    /**
+     * Continues a multiple-part encryption.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @param encryptedPart get ciphertext
+     * @param encryptedPartLen gets c-text size
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_EncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public long EncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
+        return NC.EncryptUpdate(nativeProvider, session, part, encryptedPart, encryptedPartLen);
+    }
+
+    /**
+     * Finishes a multiple-part encryption.
+     * @param session the session's handle
+     * @param lastEncryptedPart last c-text
+     * @param lastEncryptedPartLen gets last size
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_EncryptFinal(long, byte[], LongRef)
+     */
+    public long EncryptFinal(long session, byte[] lastEncryptedPart, LongRef lastEncryptedPartLen) {
+        return NC.EncryptFinal(nativeProvider, session, lastEncryptedPart, lastEncryptedPartLen);
+    }
+
+    /**
+     * Intialises a decryption operation.
+     * @param session the session's handle
+     * @param mechanism the decryption mechanism
+     * @param key handle of decryption key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DecryptInit(long, CKM, long)
+     */
+    public long DecryptInit(long session, CKM mechanism, long key) {
+        return NC.DecryptInit(nativeProvider, session, mechanism, key);
+    }
+
+    /**
+     * Decrypts encrypted data in a single part.
+     * @param session the session's handle
+     * @param encryptedData cipertext
+     * @param data gets plaintext
+     * @param dataLen gets p-text size
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     */
+    public long Decrypt(long session, byte[] encryptedData, byte[] data, LongRef dataLen) {
+        return NC.Decrypt(nativeProvider, session, encryptedData, data, dataLen);
+    }
+
+    /**
+     * Continues a multiple-part decryption.
+     * @param session the session's handle
+     * @param encryptedPart encrypted data
+     * @param data gets plaintext
+     * @param dataLen get p-text size
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DecryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public long DecryptUpdate(long session, byte[] encryptedPart, byte[] data, LongRef dataLen) {
+        return NC.DecryptUpdate(nativeProvider, session, encryptedPart, data, dataLen);
+    }
+
+    /**
+     * Finishes a multiple-part decryption.
+     * @param session the session's handle
+     * @param lastPart gets plaintext
+     * @param lastPartLen p-text size
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DecryptFinal(long, byte[], LongRef)
+     */
+    public long DecryptFinal(long session, byte[] lastPart, LongRef lastPartLen) {
+        return NC.DecryptFinal(nativeProvider, session, lastPart, lastPartLen);
+    }
+
+    /**
+     * Initialises a message-digesting operation.
+     * @param session the session's handle
+     * @param mechanism the digesting mechanism
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DigestInit(long, CKM)
+     */
+    public long DigestInit(long session, CKM mechanism) {
+        return NC.DigestInit(nativeProvider, session, mechanism);
+    }
+
+    /**
+     * Digests data in a single part.
+     * @param session the session's handle
+     * @param data data to be digested
+     * @param digest gets the message digest
+     * @param digestLen gets digest length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_Digest(long, byte[], long, byte[], LongRef)
+     */
+    public long Digest(long session, byte[] data, byte[] digest, LongRef digestLen) {
+        return NC.Digest(nativeProvider, session, data, digest, digestLen);
+    }
+
+    /**
+     * Continues a multiple-part message-digesting.
+     * @param session the session's handle
+     * @param part data to be digested
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DigestUpdate(long, byte[], long)
+     */
+    public long DigestUpdate(long session, byte[] part) {
+        return NC.DigestUpdate(nativeProvider, session, part);
+    }
+
+    /**
+     * Continues a multi-part message-digesting operation, by digesting
+     * the value of a secret key as part of the data already digested.
+     * @param session the session's handle
+     * @param key secret key to digest
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DigestKey(long, long)
+     */
+    public long DigestKey(long session, long key) {
+        return NC.DigestKey(nativeProvider, session, key);
+    }
+
+    /**
+     * Finishes a multiple-part message-digesting operation.
+     * @param session the session's handle
+     * @param digest gets the message digest
+     * @param digestLen gets byte count of digest
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DigestFinal(long, byte[], LongRef)
+     */
+    public long DigestFinal(long session, byte[] digest, LongRef digestLen) {
+        return NC.DigestFinal(nativeProvider, session, digest, digestLen);
+    }
+
+    /**
+     * Initialises a signature (private key encryption) operation, where
+     * the signature is (will be) an appendix to the data, and plaintext
+     * cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the signature mechanism
+     * @param key handle of signature key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SignInit(long, CKM, long)
+     */
+    public long SignInit(long session, CKM mechanism, long key) {
+        return NC.SignInit(nativeProvider, session, mechanism, key);
+    }
+
+    /**
+     * Signs (encrypts with private key) data in a single part, where the signature is (will be)
+     * an appendix to the data, and plaintext canot be recovered from the signature.
+     * @param session the session's handle
+     * @param data the data to sign
+     * @param signature gets the signature
+     * @param signatureLen gets signature length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_Sign(long, byte[], long, byte[], LongRef)
+     */
+    public long Sign(long session, byte[] data, byte[] signature, LongRef signatureLen) {
+        return NC.Sign(nativeProvider, session, data, signature, signatureLen);
+    }
+
+    /**
+     * Continues a multiple-part signature operation where the signature is
+     * (will be) an appendix to the data, and plaintext cannot be recovered from
+     * the signature.
+     * @param session the session's handle
+     * @param part data to sign
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SignUpdate(long, byte[], long)
+     */
+    public long SignUpdate(long session, byte[] part) {
+        return NC.SignUpdate(nativeProvider, session, part);
+    }
+
+    /**
+     * Finishes a multiple-part signature operation, returning the signature.
+     * @param session the session's handle
+     * @param signature gets the signature
+     * @param signatureLen gets signature length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SignFinal(long, byte[], LongRef)
+     */
+    public long SignFinal(long session, byte[] signature, LongRef signatureLen) {
+        return NC.SignFinal(nativeProvider, session, signature, signatureLen);
+    }
+
+    /**
+     * Initialises a signature operation, where the data can be recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the signature mechanism
+     * @param key handle f the signature key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SignRecoverInit(long, CKM, long)
+     */
+    public long SignRecoverInit(long session, CKM mechanism, long key) {
+        return NC.SignRecoverInit(nativeProvider, session, mechanism, key);
+    }
+
+    /**
+     * Signs data in a single operation, where the data can be recovered from the signature.
+     * @param session the session's handle
+     * @param data the data to sign
+     * @param signature gets the signature
+     * @param signatureLen gets signature length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SignRecover(long, byte[], long, byte[], LongRef)
+     */
+    public long SignRecover(long session, byte[] data, byte[] signature, LongRef signatureLen) {
+        return NC.SignRecover(nativeProvider, session, data, signature, signatureLen);
+    }
+
+    /**
+     * Initialises a verification operation, where the signature is an appendix to the data,
+     * and plaintet cannot be recovered from the signature (e.g. DSA).
+     * @param session the session's handle
+     * @param mechanism the verification mechanism
+     * @param key verification key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_VerifyInit(long, CKM, long)
+     */
+    public long VerifyInit(long session, CKM mechanism, long key) {
+        return NC.VerifyInit(nativeProvider, session, mechanism, key);
+    }
+
+    /**
+     * Verifies a signature in a single-part operation, where the signature is an appendix to the data,
+     * and plaintext cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param data signed data
+     * @param signature signature
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_Verify(long, byte[], long, byte[], long)
+     */
+    public long Verify(long session, byte[] data, byte[] signature) {
+        return NC.Verify(nativeProvider, session, data, signature);
+    }
+
+    /**
+     * Continues a multiple-part verification operation where the signature is an appendix to the data,
+     * and plaintet cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param part signed data
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_VerifyUpdate(long, byte[], long)
+     */
+    public long VerifyUpdate(long session, byte[] part) {
+        return NC.VerifyUpdate(nativeProvider, session, part);
+    }
+
+    /**
+     * Finishes a multiple-part verification operation, checking the signature.
+     * @param session the session's handle
+     * @param signature signature to verify
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_VerifyFinal(long, byte[], long)
+     */
+    public long VerifyFinal(long session, byte[] signature) {
+        return NC.VerifyFinal(nativeProvider, session, signature);
+    }
+
+    /**
+     * Initialises a signature verification operation, where the data is recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the verification mechanism
+     * @param key verification key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_VerifyRecoverInit(long, CKM, long)
+     */
+    public long VerifyRecoverInit(long session, CKM mechanism, long key) {
+        return NC.VerifyRecoverInit(nativeProvider, session, mechanism, key);
+    }
+
+    /**
+     * Verifies a signature in a single-part operation, where the data is recovered from the signature.
+     * @param session the session's handle
+     * @param signature signature to verify
+     * @param data gets signed data
+     * @param dataLen gets signed data length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_VerifyRecover(long, byte[], long, byte[], LongRef)
+     */
+    public long VerifyRecover(long session, byte[] signature, byte[] data, LongRef dataLen) {
+        return NC.VerifyRecover(nativeProvider, session, signature, data, dataLen);
+    }
+
+    /**
+     * Continues a multiple-part digesting and encryption operation.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @param encryptedPart gets ciphertext
+     * @param encryptedPartLen get c-text length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DigestEncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public long DigestEncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
+        return NC.DigestEncryptUpdate(nativeProvider, session, part, encryptedPart, encryptedPartLen);
+    }
+
+    /**
+     * Continues a multiple-part decryption and digesting operation.
+     * @param session the session's handle
+     * @param encryptedPart ciphertext
+     * @param part gets plaintext
+     * @param partLen gets plaintext length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DecryptDigestUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public long DecryptDigestUpdate(long session, byte[] encryptedPart, byte[] part, LongRef partLen) {
+        return NC.DecryptDigestUpdate(nativeProvider, session, encryptedPart, part, partLen);
+    }
+
+    /**
+     * Continues a multiple-part signing and encryption operation.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @param encryptedPart gets ciphertext
+     * @param encryptedPartLen gets c-text length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SignEncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public long SignEncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
+        return NC.SignEncryptUpdate(nativeProvider, session, part, encryptedPart, encryptedPartLen);
+    }
+
+    /**
+     * Continues a multiple-part decryption and verify operation.
+     * @param session the session's handle
+     * @param encryptedPart ciphertext
+     * @param part gets plaintext
+     * @param partLen gets p-text length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DecryptVerifyUpdate(long, byte[], long, byte[], LongRef)
+     */
+    public long DecryptVerifyUpdate(long session, byte[] encryptedPart, byte[] part, LongRef partLen) {
+        return NC.DecryptVerifyUpdate(nativeProvider, session, encryptedPart, part, partLen);
+    }
+
+    /**
+     * Generates a secret key, creating a new key.
+     * @param session the session's handle
+     * @param mechanism key generation mechanism
+     * @param templ template for the new key
+     * @param key gets handle of new key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GenerateKey(long, CKM, CKA[], long, LongRef)
+     */
+    public long GenerateKey(long session, CKM mechanism, CKA[] templ, LongRef key) {
+        return NC.GenerateKey(nativeProvider, session, mechanism, templ, key);
+    }
+
+    /**
+     * Generates a public-key / private-key pair, create new key objects.
+     * @param session the session's handle
+     * @param mechanism key generation mechansim
+     * @param publicKeyTemplate template for the new public key
+     * @param privateKeyTemplate template for the new private key
+     * @param publicKey gets handle of new public key
+     * @param privateKey gets handle of new private key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GenerateKeyPair(long, CKM, CKA[], long, CKA[], long, LongRef, LongRef)
+     */
+    public long GenerateKeyPair(long session, CKM mechanism, CKA[] publicKeyTemplate,
+                                       CKA[] privateKeyTemplate, LongRef publicKey, LongRef privateKey) {
+        return NC.GenerateKeyPair(nativeProvider, session, mechanism, publicKeyTemplate, privateKeyTemplate, publicKey, privateKey);
+    }
+
+    /**
+     * Wraps (encrypts) a key.
+     * @param session the session's handle
+     * @param mechanism the wrapping mechanism
+     * @param wrappingKey wrapping key
+     * @param key key to be wrapped
+     * @param wrappedKey gets wrapped key
+     * @param wrappedKeyLen gets wrapped key length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_WrapKey(long, CKM, long, long, byte[], LongRef)
+     */
+    public long WrapKey(long session, CKM mechanism, long wrappingKey, long key,
+                               byte[] wrappedKey, LongRef wrappedKeyLen) {
+
+        return NC.WrapKey(nativeProvider, session, mechanism, wrappingKey, key, wrappedKey, wrappedKeyLen);
+    }
+
+    /**
+     * Unwraps (decrypts) a wrapped key, creating a new key object.
+     * @param session the session's handle
+     * @param mechanism unwrapping mechanism
+     * @param unwrappingKey unwrapping key
+     * @param wrappedKey the wrapped key
+     * @param templ new key template
+     * @param key gets new handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_UnwrapKey(long, CKM, long, byte[], long, CKA[], long, LongRef)
+     */
+    public long UnwrapKey(long session, CKM mechanism, long unwrappingKey, byte[] wrappedKey,
+            CKA[] templ, LongRef key) {
+        return NC.UnwrapKey(nativeProvider, session, mechanism, unwrappingKey, wrappedKey, templ, key);
+    }
+
+    /**
+     * Derives a key from a base key, creating a new key object.
+     * @param session the session's handle
+     * @param mechanism key derivation mechanism
+     * @param baseKey base key
+     * @param templ new key template
+     * @param key ges new handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DeriveKey(long, CKM, long, CKA[], long, LongRef)
+     */
+    public long DeriveKey(long session, CKM mechanism, long baseKey, CKA[] templ, LongRef key) {
+        return NC.DeriveKey(nativeProvider, session, mechanism, baseKey, templ, key);
+    }
+
+    /**
+     * Mixes additional seed material into the token's random number generator.
+     * @param session the session's handle
+     * @param seed the seed material
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SeedRandom(long, byte[], long)
+     */
+    public long SeedRandom(long session, byte[] seed) {
+        return NC.SeedRandom(nativeProvider, session, seed);
+    }
+
+    /**
+     * Generates random or pseudo-random data.
+     * @param session the session's handle
+     * @param randomData receives the random data
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GenerateRandom(long, byte[], long)
+     */
+    public long GenerateRandom(long session, byte[] randomData) {
+        return NC.GenerateRandom(nativeProvider, session, randomData);
+    }
+
+    /**
+     * In previous versions of Cryptoki, C_GetFunctionStatus obtained the status of a function running in parallel
+     * with an application. Now, however, C_GetFunctionStatus is a legacy function which should simply return
+     * the value CKR_FUNCTION_NOT_PARALLEL.
+     * @param session the session's handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetFunctionStatus(long)
+     */
+    public long GetFunctionStatus(long session) {
+        return NC.GetFunctionStatus(nativeProvider, session);
+    }
+
+    /**
+     * In previous versions of Cryptoki, C_CancelFunction cancelled a function running in parallel with an application.
+     * Now, however, C_CancelFunction is a legacy function which should simply return the value
+     * CKR_FUNCTION_NOT_PARALLEL.
+     * @param session the session's handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_CancelFunction(long)
+     */
+    public long CancelFunction(long session) {
+        return NC.CancelFunction(nativeProvider, session);
+    }
+}

--- a/src/main/java/org/pkcs11/jacknji11/NC.java
+++ b/src/main/java/org/pkcs11/jacknji11/NC.java
@@ -1,0 +1,1512 @@
+/*
+ * Copyright 2010-2011 Joel Hockey (joel.hockey@gmail.com). All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.pkcs11.jacknji11;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Low-level java interface that maps to {@link NativeProvider} cryptoki calls.
+ *
+ * jacknji11 provides 3 interfaces for calling cryptoki functions.
+ * <ol>
+ * <li>{@link NativeProvider} provides the lowest level
+ * direct mapping to the <code>'C_*'</code> functions.  There is little
+ * reason why you would ever want to invoke it directly, but you can.
+ * <li>{@link NC} provides the exact same functions
+ * as {@link NativeProvider} by calling through to the
+ * corresponding native method.  The <code>'C_'</code> at the start of the
+ * function name is removed since the <code>'C.'</code> when you call the
+ * static methods of this class looks similar.  In addition to calling
+ * the native methods, {@link NC} provides logging
+ * through apache commons logging.  You can use this if you require fine-grain
+ * control over something such as checking
+ * {@link CKR} return codes.
+ * <li>{@link CE} (<b>C</b>ryptoki
+ * with <b>E</b>xceptions) provides the most user-friendly interface
+ * and is the preferred interface to use.  It calls
+ * related function(s) in {@link NC},
+ * and converts any non-zero return values into a
+ * {@link CKRException}.  It automatically resizes
+ * arrays and other helpful things.
+ * </ol>
+ *
+ * @author Joel Hockey (joel.hockey@gmail.com)
+ */
+public class NC {
+    private static final Log log = LogFactory.getLog(NC.class);
+
+    private static final NativePointer NULL = new NativePointer(0);
+
+    /**
+     * Read custom library from environment JACKNJI11_PKCS11_LIB_PATH,
+     * or use default 'cryptoki'.
+     * @return library name
+     */
+    public static String getLibraryName() {
+        String lib = System.getenv("JACKNJI11_PKCS11_LIB_PATH");
+        if (lib == null || lib.length() == 0) {
+            lib = "cryptoki";
+        }
+        log.debug("Loading native library " + lib);
+        return lib;
+    }
+
+    /**
+     * Initialise Cryptoki with null mutexes, and CKF_OS_LOCKING_OK flag set.
+     * @param nativeProvider the native provider instance
+     * @see NativeProvider#C_Initialize(CK_C_INITIALIZE_ARGS)
+     * @return {@link CKR} return code
+     */
+    static long Initialize(NativeProvider nativeProvider) {
+        CK_C_INITIALIZE_ARGS args = new CK_C_INITIALIZE_ARGS(null, null, null, null,
+                CK_C_INITIALIZE_ARGS.CKF_OS_LOCKING_OK);
+        return Initialize(nativeProvider, args);
+    }
+
+    /**
+     * Initialise Cryptoki with supplied args.
+     * @param nativeProvider the native provider instance
+     * @see NativeProvider#C_Initialize(CK_C_INITIALIZE_ARGS)
+     * @return {@link CKR} return code
+     */
+    static long Initialize(NativeProvider nativeProvider, CK_C_INITIALIZE_ARGS pInitArgs) {
+        if (log.isDebugEnabled()) log.debug("> C_Initialize " + pInitArgs);
+        long rv = nativeProvider.C_Initialize(pInitArgs);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_Initialize rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Called to indicate that an application is finished with the Cryptoki library.
+     * @param nativeProvider the native provider instance
+     * @see NativeProvider#C_Finalize(NativePointer)
+     * @return {@link CKR} return code
+     */
+    static long Finalize(NativeProvider nativeProvider) {
+        if (log.isDebugEnabled()) log.debug("> C_Finalize");
+        long rv = nativeProvider.C_Finalize(NULL);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_Finalize rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Returns general information about Cryptoki.
+     * @param nativeProvider the native provider instance
+     * @param info location that receives information
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetInfo(CK_INFO)
+     */
+    static long GetInfo(NativeProvider nativeProvider, CK_INFO info) {
+        if (log.isDebugEnabled()) log.debug("> C_GetInfo");
+        long rv = nativeProvider.C_GetInfo(info);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_GetInfo rv=0x%08x{%s}\n%s", rv, CKR.L2S(rv), info));
+        return rv;
+    }
+
+    /**
+     * Obtains a list of slots in the system.
+     * @param nativeProvider the native provider instance
+     * @param tokenPresent only slots with tokens?
+     * @param slotList receives array of slot IDs
+     * @param count receives the number of slots
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef)
+     */
+    static long GetSlotList(NativeProvider nativeProvider, boolean tokenPresent, long[] slotList, LongRef count) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_GetSlotList tokenPresent=%b count=%d", tokenPresent, count.value()));
+        long rv = nativeProvider.C_GetSlotList(tokenPresent, slotList, count);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_GetSlotList rv=0x%08x{%s} count=%d\n  %s", rv, CKR.L2S(rv), count.value(), Arrays.toString(slotList)));
+        return rv;
+    }
+
+    /**
+     * Obtains information about a particular slot in the system.
+     * @param nativeProvider the native provider instance
+     * @param slotID the ID of the slot
+     * @param info receives the slot information
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetSlotInfo(long, CK_SLOT_INFO)
+     */
+    static long GetSlotInfo(NativeProvider nativeProvider, long slotID, CK_SLOT_INFO info) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_GetSlotInfo slotID=%d", slotID));
+        long rv = nativeProvider.C_GetSlotInfo(slotID, info);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_GetSlotInfo rv=0x%08x{%s}\n%s", rv, CKR.L2S(rv), info));
+        return rv;
+    }
+
+    /**
+     * Obtains information about a particular token in the system.
+     * @param nativeProvider the native provider instance
+     * @param slotID ID of the token's slot
+     * @param info receives the token information
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetTokenInfo(long, CK_TOKEN_INFO)
+     */
+    static long GetTokenInfo(NativeProvider nativeProvider, long slotID, CK_TOKEN_INFO info) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_GetTokenInfo slotID=%d", slotID));
+        long rv = nativeProvider.C_GetTokenInfo(slotID, info);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_GetTokenInfo rv=0x%08x{%s}\n%s", rv, CKR.L2S(rv), info));
+        return rv;
+    }
+
+    /**
+     * Waits for a slot event (token insertion, removal, etc.) to occur.
+     * @param nativeProvider the native provider instance
+     * @param flags blocking/nonblocking flag
+     * @param slot location that receives the slot ID
+     * @param reserved reserved.  Should be null
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_WaitForSlotEvent(long, LongRef, NativePointer)
+     */
+    static long WaitForSlotEvent(NativeProvider nativeProvider, long flags, LongRef slot, NativePointer reserved) {
+        if (log.isDebugEnabled()) log.debug("> C_WaitForSlotEvent");
+        long rv = nativeProvider.C_WaitForSlotEvent(flags, slot, reserved != null ? reserved : NULL);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_WaitForSlotEvent rv=0x%08x{%s} slot=%d", rv, CKR.L2S(rv), slot.value()));
+        return rv;
+    }
+
+    /**
+     * Obtains a list of mechanism types supported by a token.
+     * @param nativeProvider the native provider instance
+     * @param slotID ID of token's slot
+     * @param mechanismList gets mechanism array
+     * @param count gets # of mechanisms
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetMechanismList(long, long[], LongRef)
+     */
+    static long GetMechanismList(NativeProvider nativeProvider, long slotID, long[] mechanismList, LongRef count) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_GetMechanismList slotID=%d count=%d", slotID, count.value()));
+        long rv = nativeProvider.C_GetMechanismList(slotID, mechanismList, count);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_GetMechanismList rv=0x%08x{%s} count=%d", rv, CKR.L2S(rv), count.value()));
+            if (mechanismList != null) {
+                sb.append('\n');
+                for (long m : mechanismList) {
+                    sb.append(String.format("  0x%08x{%s}\n", m, CKM.L2S(m)));
+                }
+            }
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Obtains information about a particular mechanism possibly supported by a token.
+     * @param nativeProvider the native provider instance
+     * @param slotID ID of the token's slot
+     * @param type {@link CKM} type of mechanism
+     * @param info receives mechanism info
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetMechanismInfo(long, long, CK_MECHANISM_INFO)
+     */
+    static long GetMechanismInfo(NativeProvider nativeProvider, long slotID, long type, CK_MECHANISM_INFO info) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_GetMechanismInfo slotID=%d type=0x%08x{%s}", slotID, type, CKM.L2S(type)));
+        long rv = nativeProvider.C_GetMechanismInfo(slotID, type, info);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_GetMechanismInfo rv=0x%08x{%s}\n%s", rv, CKR.L2S(rv), info));
+        return rv;
+    }
+
+    /**
+     * Initialises a token.  Pad or truncate label if required.
+     * @param nativeProvider the native provider instance
+     * @param slotID ID of the token's slot
+     * @param pin the SO's initial PIN
+     * @param label 32-byte token label (space padded).  If not 32 bytes, then
+     * it will be padded or truncated as required
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_InitToken(long, byte[], long, byte[])
+     */
+    static long InitToken(NativeProvider nativeProvider, long slotID, byte[] pin, byte[] label) {
+        byte[] label32;
+        if (label != null && label.length == 32) {
+            label32 = label;
+        } else {
+            label32 = new byte[32];
+            Arrays.fill(label32, (byte) 0x20); // space fill
+            if (label != null) {
+                System.arraycopy(label, 0, label32, 0, Math.min(label32.length, label.length));
+            }
+        }
+        if (log.isDebugEnabled()) log.debug(String.format("> C_InitToken slotID=%d pin=*** label=%s", slotID, Buf.escstr(label32)));
+        long rv = nativeProvider.C_InitToken(slotID, pin, baLen(pin), label32);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_InitToken rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Initialise normal user with PIN.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param pin the normal user's PIN
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_InitPIN(long, byte[], long)
+     */
+    static long InitPIN(NativeProvider nativeProvider, long session, byte[] pin) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_InitPIN session=0x%08x pin=***", session));
+        long rv = nativeProvider.C_InitPIN(session, pin, baLen(pin));
+        if (log.isDebugEnabled()) log.debug(String.format("< C_InitPIN rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Change PIN.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param oldPin old PIN
+     * @param newPin new PIN
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SetPIN(long, byte[], long, byte[], long)
+     */
+    static long SetPIN(NativeProvider nativeProvider, long session, byte[] oldPin, byte[] newPin) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_SetPIN session=0x%08x oldPin=*** newPin=***", session));
+        long rv = nativeProvider.C_SetPIN(session, oldPin, baLen(oldPin), newPin, baLen(newPin));
+        if (log.isDebugEnabled()) log.debug(String.format("< C_SetPIN rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Opens a session between an application and a token.
+     * @param nativeProvider the native provider instance
+     * @param slotID the slot's ID
+     * @param flags from {@link CK_SESSION_INFO}
+     * @param application passed to callback (ok to leave it null)
+     * @param notify callback function (ok to leave it null)
+     * @param session gets session handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
+     */
+    static long OpenSession(NativeProvider nativeProvider, long slotID, long flags, NativePointer application, CK_NOTIFY notify, LongRef session) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_OpenSession slotID=%d flags=0x%08x{%s} application=%s notify=%s", slotID, flags, CK_SESSION_INFO.f2s(flags), application, notify));
+        long rv = nativeProvider.C_OpenSession(slotID, flags, application != null ? application : NULL, notify, session);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_OpenSession rv=0x%08x{%s} session=0x%08x", rv, CKR.L2S(rv), session.value()));
+        return rv;
+    }
+
+    /**
+     * Closes a session between an application and a token.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_CloseSession(long)
+     */
+    static long CloseSession(NativeProvider nativeProvider, long session) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_CloseSession session=0x%08x", session));
+        long rv = nativeProvider.C_CloseSession(session);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_CloseSession rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Closes all sessions with a token.
+     * @param nativeProvider the native provider instance
+     * @param slotID the token's slot
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_CloseAllSessions(long)
+     */
+    static long CloseAllSessions(NativeProvider nativeProvider, long slotID) {
+        if (log.isDebugEnabled()) log.debug("> C_CloseAllSessions");
+        long rv = nativeProvider.C_CloseAllSessions(slotID);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_CloseAllSessions rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Obtains information about the session.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param info receives session info
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetSessionInfo(long, CK_SESSION_INFO)
+     */
+    static long GetSessionInfo(NativeProvider nativeProvider, long session, CK_SESSION_INFO info) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_GetSessionInfo session=0x%08x", session));
+        long rv = nativeProvider.C_GetSessionInfo(session, info);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_GetSessionInfo rv=0x%08x{%s}\n%s", rv, CKR.L2S(rv), info));
+        return rv;
+    }
+
+    /**
+     * Obtains the state of the cryptographic operation.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param operationState gets state
+     * @param operationStateLen gets state length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetOperationState(long, byte[], LongRef)
+     */
+    static long GetOperationState(NativeProvider nativeProvider, long session, byte[] operationState, LongRef operationStateLen) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_GetOperationState session=0x%08x operationStateLen=%d", session, operationStateLen.value()));
+        long rv = nativeProvider.C_GetOperationState(session, operationState, operationStateLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_GetOperationState rv=0x%08x{%s}\n  operationState (len=%d):\n", rv, CKR.L2S(rv), operationStateLen.value()));
+            if (operationState != null) {
+                Hex.dump(sb, operationState, 0, (int) operationStateLen.value(), "  ", 32, false);
+            }
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Restores the state of the cryptographic operation in a session.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param operationState holds state
+     * @param encryptionKey en/decryption key
+     * @param authenticationKey sign/verify key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SetOperationState(long, byte[], long, long, long)
+     */
+    static long SetOperationState(NativeProvider nativeProvider, long session, byte[] operationState,
+                                         long encryptionKey, long authenticationKey) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format(
+                    "> C_SetOperationState session=0x%08x encryptionKey=0x%08x authenticationKey=0x%08x\n  operationState (len=%d):\n",
+                    session, encryptionKey, authenticationKey, operationState.length));
+            Hex.dump(sb, operationState, 0, operationState.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_SetOperationState(session, operationState, baLen(operationState),
+                encryptionKey, authenticationKey);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_SetOperationState rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Logs a user into a token.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param userType the user type from {@link CKU}
+     * @param pin the user's PIN
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_Login(long, long, byte[], long)
+     */
+    static long Login(NativeProvider nativeProvider, long session, long userType, byte[] pin) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_Login session=0x%08x userType=0x%08x{%s} pin=***", session, userType, CKU.L2S(userType)));
+        long rv = nativeProvider.C_Login(session, userType, pin, baLen(pin));
+        if (log.isDebugEnabled()) log.debug(String.format("< C_Login rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Logs a user out from a token.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_Logout(long)
+     */
+    static long Logout(NativeProvider nativeProvider, long session) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_Logout session=0x%08x", session));
+        long rv = nativeProvider.C_Logout(session);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_Logout rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Creates a new object.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param templ the objects template
+     * @param object gets new object's handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_CreateObject(long, CKA[], long, LongRef)
+     */
+    static long CreateObject(NativeProvider nativeProvider, long session, CKA[] templ, LongRef object) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_CreateObject session=0x%08x\n", session));
+            dumpTemplate(sb, templ);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_CreateObject(session, templ, templLen(templ), object);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_CreateObject rv=0x%08x{%s} object=0x%08x", rv, CKR.L2S(rv), object.value()));
+        return rv;
+    }
+
+    /**
+     * Copies an object, creating a new object for the copy.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param object the object's handle
+     * @param templ template for new object
+     * @param newObject receives handle of copy
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_CopyObject(long, long, CKA[], long, LongRef)
+     */
+    static long CopyObject(NativeProvider nativeProvider, long session, long object, CKA[] templ, LongRef newObject) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_CopyObject session=0x%08x object=0x%08x\n", session, object));
+            dumpTemplate(sb, templ);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_CopyObject(session, object, templ, templLen(templ), newObject);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_CopyObject rv=0x%08x{%s} newObject=0x%08x", rv, CKR.L2S(rv), newObject.value()));
+        return rv;
+    }
+
+    /**
+     * Destroys an object.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param object the object's handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DestroyObject(long, long)
+     */
+    static long DestroyObject(NativeProvider nativeProvider, long session, long object) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_DestroyObject session=0x%08x object=0x%08x", session, object));
+        long rv = nativeProvider.C_DestroyObject(session, object);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_DestroyObject rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Gets the size of an object in bytes.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param object the object's handle
+     * @param size receives the size of object
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetObjectSize(long, long, LongRef)
+     */
+    static long GetObjectSize(NativeProvider nativeProvider, long session, long object, LongRef size) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_GetObjectSize session=0x%08x object=0x%08x", session, object));
+        long rv = nativeProvider.C_GetObjectSize(session, object, size);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_GetObjectSize rv=0x%08x{%s} size=%d", rv, CKR.L2S(rv), size.value()));
+        return rv;
+    }
+
+    /**
+     * Obtains the value of one or more object attributes.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param object the objects's handle
+     * @param templ specifies attributes, gets values
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetAttributeValue(long, long, CKA[], long)
+     */
+    static long GetAttributeValue(NativeProvider nativeProvider, long session, long object, CKA[] templ) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_GetAttributeValue session=0x%08x object=0x%08x\n", session, object));
+            dumpTemplate(sb, templ);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_GetAttributeValue(session, object, templ, templLen(templ));
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_GetAttributeValue rv=0x%08x{%s}\n", rv, CKR.L2S(rv)));
+            dumpTemplate(sb, templ);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Modifies the values of one or more object attributes.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param object the object's handle
+     * @param templ specifies attributes and values
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SetAttributeValue(long, long, CKA[], long)
+     */
+    static long SetAttributeValue(NativeProvider nativeProvider, long session, long object, CKA[] templ) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_SetAttributeValue session=0x%08x object=0x%08x\n", session, object));
+            dumpTemplate(sb, templ);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_SetAttributeValue(session, object, templ, templLen(templ));
+        if (log.isDebugEnabled()) log.debug(String.format("< C_SetAttributeValue rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Initialises a search for token and session objects that match a template.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param templ attribute values to match
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_FindObjectsInit(long, CKA[], long)
+     */
+    static long FindObjectsInit(NativeProvider nativeProvider, long session, CKA[] templ) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_FindObjectsInit session=0x%08x\n", session));
+            dumpTemplate(sb, templ);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_FindObjectsInit(session, templ, templLen(templ));
+        if (log.isDebugEnabled()) log.debug(String.format("< C_FindObjectsInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Continues a search for token and session objects that match a template,
+     * obtaining additional object handles.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param found gets object handles
+     * @param objectCount number of object handles returned
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_FindObjects(long, long[], long, LongRef)
+     */
+    static long FindObjects(NativeProvider nativeProvider, long session, long[] found, LongRef objectCount) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_FindObjects session=0x%08x maxObjectCount=%d", session, found != null ? found.length : 0));
+        long rv = nativeProvider.C_FindObjects(session, found, found == null ? 0 : found.length, objectCount);
+        if (log.isDebugEnabled()) {
+            int l = (int) objectCount.value();
+            // only debug found[0:l]
+            long[] toDisplay = found;
+            if (l < found.length) {
+                toDisplay = new long[l];
+                System.arraycopy(found, 0, toDisplay, 0, l);
+            }
+            log.debug(String.format("< C_FindObjects rv=0x%08x{%s} objectCount=%d\n  %s", rv, CKR.L2S(rv), objectCount.value(), Arrays.toString(toDisplay)));
+        }
+        return rv;
+    }
+
+    /**
+     * Finishes a search for token and session objects.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_FindObjectsFinal(long)
+     */
+    static long FindObjectsFinal(NativeProvider nativeProvider, long session) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_FindObjectsFinal session=0x%08x", session));
+        long rv = nativeProvider.C_FindObjectsFinal(session);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_FindObjectsFinal rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Initialises an encryption operation.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param mechanism the encryption mechanism
+     * @param key handle of encryption key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_EncryptInit(long, CKM, long)
+     */
+    static long EncryptInit(NativeProvider nativeProvider, long session, CKM mechanism, long key) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_EncryptInit session=0x%08x key=0x%08x\n  %s", session, key, mechanism));
+        long rv = nativeProvider.C_EncryptInit(session, mechanism, key);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_EncryptInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Encrypts single-part data.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param data the plaintext data
+     * @param encryptedData gets ciphertext
+     * @param encryptedDataLen gets c-text size
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     */
+    static long Encrypt(NativeProvider nativeProvider, long session, byte[] data, byte[] encryptedData, LongRef encryptedDataLen) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_Encrypt session=0x%08x encryptedDataLen=%d data\n  (len=%d):\n", session, encryptedDataLen.value(), data.length));
+            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_Encrypt(session, data, baLen(data), encryptedData, encryptedDataLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_Encrypt rv=0x%08x{%s}\n  encryptedData (len=%d):\n", rv, CKR.L2S(rv), encryptedDataLen.value()));
+            Hex.dump(sb, encryptedData, 0, (int) encryptedDataLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Continues a multiple-part encryption.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @param encryptedPart get ciphertext
+     * @param encryptedPartLen gets c-text size
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_EncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static long EncryptUpdate(NativeProvider nativeProvider, long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_EncryptUpdate session=0x%08x encryptedPartLen=%d\n  part (len=%d):\n", session, encryptedPartLen.value(), part.length));
+            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_EncryptUpdate(session, part, baLen(part), encryptedPart, encryptedPartLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_EncryptUpdate rv=0x%08x{%s}\n  encryptedPart (len=%d):\n", rv, CKR.L2S(rv), encryptedPartLen.value()));
+            Hex.dump(sb, encryptedPart, 0, (int) encryptedPartLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Finishes a multiple-part encryption.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param lastEncryptedPart last c-text
+     * @param lastEncryptedPartLen gets last size
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_EncryptFinal(long, byte[], LongRef)
+     */
+    static long EncryptFinal(NativeProvider nativeProvider, long session, byte[] lastEncryptedPart, LongRef lastEncryptedPartLen) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_EncryptFinal session=0x%08x lastEncryptedPartLen=%d", session, lastEncryptedPartLen.value()));
+        long rv = nativeProvider.C_EncryptFinal(session, lastEncryptedPart, lastEncryptedPartLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_EncryptFinal rv=0x%08x{%s}\n  lastEncryptedPart (len=%d):\n", rv, CKR.L2S(rv), lastEncryptedPartLen.value()));
+            Hex.dump(sb, lastEncryptedPart, 0, (int) lastEncryptedPartLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Intialises a decryption operation.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param mechanism the decryption mechanism
+     * @param key handle of decryption key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DecryptInit(long, CKM, long)
+     */
+    static long DecryptInit(NativeProvider nativeProvider, long session, CKM mechanism, long key) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_DecryptInit session=0x%08x key=0x%08x\n  %s", session, key, mechanism));
+        long rv = nativeProvider.C_DecryptInit(session, mechanism, key);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_DecryptInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Decrypts encrypted data in a single part.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param encryptedData cipertext
+     * @param data gets plaintext
+     * @param dataLen gets p-text size
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     */
+    static long Decrypt(NativeProvider nativeProvider, long session, byte[] encryptedData, byte[] data, LongRef dataLen) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_Decrypt session=0x%08x dataLen=%d\n encryptedData (len=%d):\n", session, dataLen.value(), encryptedData.length));
+            Hex.dump(sb, encryptedData, 0, encryptedData.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_Decrypt(session, encryptedData, baLen(encryptedData), data, dataLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_Decrypt rv=0x%08x{%s}\n  data (len=%d):\n", rv, CKR.L2S(rv), dataLen.value()));
+            Hex.dump(sb, data, 0, (int) dataLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Continues a multiple-part decryption.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param encryptedPart encrypted data
+     * @param data gets plaintext
+     * @param dataLen get p-text size
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DecryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static long DecryptUpdate(NativeProvider nativeProvider, long session, byte[] encryptedPart, byte[] data, LongRef dataLen) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_DecryptUpdate session=0x%08x dataLen=%d\n  encryptedPart (len=%d):\n", session, dataLen.value(), encryptedPart.length));
+            Hex.dump(sb, encryptedPart, 0, encryptedPart.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_DecryptUpdate(session, encryptedPart, baLen(encryptedPart), data, dataLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_DecryptUpdate rv=0x%08x{%s}\n  data (len=%d):\n", rv, CKR.L2S(rv), dataLen.value()));
+            Hex.dump(sb, data, 0, (int) dataLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Finishes a multiple-part decryption.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param lastPart gets plaintext
+     * @param lastPartLen p-text size
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DecryptFinal(long, byte[], LongRef)
+     */
+    static long DecryptFinal(NativeProvider nativeProvider, long session, byte[] lastPart, LongRef lastPartLen) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_DecryptFinal session=0x%08x lastPartLen=%d", session, lastPartLen.value()));
+        long rv = nativeProvider.C_DecryptFinal(session, lastPart, lastPartLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_DecryptFinal rv=0x%08x{%s}\n  lastPart (len=%d):\n", rv, CKR.L2S(rv), lastPartLen.value()));
+            Hex.dump(sb, lastPart, 0, (int) lastPartLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Initialises a message-digesting operation.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param mechanism the digesting mechanism
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DigestInit(long, CKM)
+     */
+    static long DigestInit(NativeProvider nativeProvider, long session, CKM mechanism) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_DigestInit session=0x%08x\n  %s", session, mechanism));
+        long rv = nativeProvider.C_DigestInit(session, mechanism);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_DigestInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Digests data in a single part.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param data data to be digested
+     * @param digest gets the message digest
+     * @param digestLen gets digest length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_Digest(long, byte[], long, byte[], LongRef)
+     */
+    static long Digest(NativeProvider nativeProvider, long session, byte[] data, byte[] digest, LongRef digestLen) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_Digest session=0x%08x digestLen=%d\n  data (len=%d):\n", session, digestLen.value(), data.length));
+            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_Digest(session, data, baLen(data), digest, digestLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_Digest rv=0x%08x{%s}\n  digest (len=%d):\n", rv, CKR.L2S(rv), digestLen.value()));
+            Hex.dump(sb, digest, 0, (int) digestLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Continues a multiple-part message-digesting.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param part data to be digested
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DigestUpdate(long, byte[], long)
+     */
+    static long DigestUpdate(NativeProvider nativeProvider, long session, byte[] part) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_DigestUpdate session=0x%08x\n  part (len=%d):\n", session, part.length));
+            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_DigestUpdate(session, part, baLen(part));
+        if (log.isDebugEnabled()) log.debug(String.format("< C_DigestUpdate rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Continues a multi-part message-digesting operation, by digesting
+     * the value of a secret key as part of the data already digested.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param key secret key to digest
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DigestKey(long, long)
+     */
+    static long DigestKey(NativeProvider nativeProvider, long session, long key) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_DigestKey session=0x%08x key=0x%08x", session, key));
+        long rv = nativeProvider.C_DigestKey(session, key);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_DigestKey rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Finishes a multiple-part message-digesting operation.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param digest gets the message digest
+     * @param digestLen gets byte count of digest
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DigestFinal(long, byte[], LongRef)
+     */
+    static long DigestFinal(NativeProvider nativeProvider, long session, byte[] digest, LongRef digestLen) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_DigestFial session=0x%08x digestLen=%d", session, digestLen.value()));
+        long rv = nativeProvider.C_DigestFinal(session, digest, digestLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_DigestFinal rv=0x%08x{%s}\n  digest (len=%d):\n", rv, CKR.L2S(rv), digestLen.value()));
+            Hex.dump(sb, digest, 0, (int) digestLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Initialises a signature (private key encryption) operation, where
+     * the signature is (will be) an appendix to the data, and plaintext
+     * cannot be recovered from the signature.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param mechanism the signature mechanism
+     * @param key handle of signature key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SignInit(long, CKM, long)
+     */
+    static long SignInit(NativeProvider nativeProvider, long session, CKM mechanism, long key) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_SignInit session=0x%08x key=0x%08x\n  %s", session, key, mechanism));
+        long rv = nativeProvider.C_SignInit(session, mechanism, key);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_SignInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Signs (encrypts with private key) data in a single part, where the signature is (will be)
+     * an appendix to the data, and plaintext canot be recovered from the signature.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param data the data to sign
+     * @param signature gets the signature
+     * @param signatureLen gets signature length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_Sign(long, byte[], long, byte[], LongRef)
+     */
+    static long Sign(NativeProvider nativeProvider, long session, byte[] data, byte[] signature, LongRef signatureLen) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_Sign session=0x%08x signatureLen=%d\n  data (len=%d):\n", session, signatureLen.value(), data.length));
+            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_Sign(session, data, baLen(data), signature, signatureLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_Sign rv=0x%08x{%s}\n  signature (len=%d):\n", rv, CKR.L2S(rv), signatureLen.value()));
+            Hex.dump(sb, signature, 0, (int) signatureLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Continues a multiple-part signature operation where the signature is
+     * (will be) an appendix to the data, and plaintext cannot be recovered from
+     * the signature.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param part data to sign
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SignUpdate(long, byte[], long)
+     */
+    static long SignUpdate(NativeProvider nativeProvider, long session, byte[] part) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_SignUpdate session=0x%08x\n  part (len=%d):\n", session, part.length));
+            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_SignUpdate(session, part, baLen(part));
+        if (log.isDebugEnabled()) log.debug(String.format("< C_SignUpdate rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Finishes a multiple-part signature operation, returning the signature.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param signature gets the signature
+     * @param signatureLen gets signature length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SignFinal(long, byte[], LongRef)
+     */
+    static long SignFinal(NativeProvider nativeProvider, long session, byte[] signature, LongRef signatureLen) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_SignFinal session=0x%08x signatureLen=%d", session, signatureLen.value()));
+        long rv = nativeProvider.C_SignFinal(session, signature, signatureLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_SignFinal rv=0x%08x{%s}\n  signature (len=%d):\n", rv, CKR.L2S(rv), signatureLen.value()));
+            Hex.dump(sb, signature, 0, (int) signatureLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Initialises a signature operation, where the data can be recovered from the signature.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param mechanism the signature mechanism
+     * @param key handle f the signature key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SignRecoverInit(long, CKM, long)
+     */
+    static long SignRecoverInit(NativeProvider nativeProvider, long session, CKM mechanism, long key) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_SignRecoverInit session=0x%08x key=0x%08x\n  %s", session, key, mechanism));
+        long rv = nativeProvider.C_SignRecoverInit(session, mechanism, key);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_SignRecoverInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Signs data in a single operation, where the data can be recovered from the signature.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param data the data to sign
+     * @param signature gets the signature
+     * @param signatureLen gets signature length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SignRecover(long, byte[], long, byte[], LongRef)
+     */
+    static long SignRecover(NativeProvider nativeProvider, long session, byte[] data, byte[] signature, LongRef signatureLen) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_SignRecover session=0x%08x signatureLen=%d\n  data (len=%d):\n", session, signatureLen.value(), data.length));
+            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_SignRecover(session, data, baLen(data), signature, signatureLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_SignRecover rv=0x%08x{%s}\n  signature (len=%d):\n", rv, CKR.L2S(rv), signatureLen.value()));
+            Hex.dump(sb, signature, 0, (int) signatureLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Initialises a verification operation, where the signature is an appendix to the data,
+     * and plaintet cannot be recovered from the signature (e.g. DSA).
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param mechanism the verification mechanism
+     * @param key verification key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_VerifyInit(long, CKM, long)
+     */
+    static long VerifyInit(NativeProvider nativeProvider, long session, CKM mechanism, long key) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_VerifyInit session=0x%08x key=0x%08x\n  %s", session, key, mechanism));
+        long rv = nativeProvider.C_VerifyInit(session, mechanism, key);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_VerifyInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Verifies a signature in a single-part operation, where the signature is an appendix to the data,
+     * and plaintext cannot be recovered from the signature.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param data signed data
+     * @param signature signature
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_Verify(long, byte[], long, byte[], long)
+     */
+    static long Verify(NativeProvider nativeProvider, long session, byte[] data, byte[] signature) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_Verify session=0x%08x\n  data (len=%d):\n", session, data.length));
+            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
+            sb.append("\n  signature (len=%d):\n");
+            Hex.dump(sb, signature, 0, signature.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_Verify(session, data, baLen(data), signature, baLen(signature));
+        log.debug(String.format("< C_Verify rv=0x%08x{%s} ", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Continues a multiple-part verification operation where the signature is an appendix to the data,
+     * and plaintet cannot be recovered from the signature.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param part signed data
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_VerifyUpdate(long, byte[], long)
+     */
+    static long VerifyUpdate(NativeProvider nativeProvider, long session, byte[] part) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_VerifyUpdate session=0x%08x\n  part (len=%d):\n", session, part.length));
+            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_VerifyUpdate(session, part, baLen(part));
+        if (log.isDebugEnabled()) log.debug(String.format("< C_VerifyUpdate rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Finishes a multiple-part verification operation, checking the signature.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param signature signature to verify
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_VerifyFinal(long, byte[], long)
+     */
+    static long VerifyFinal(NativeProvider nativeProvider, long session, byte[] signature) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_VerifyFinal session=0x%08x\n  signature (len=%d):\n", session, signature.length));
+            Hex.dump(sb, signature, 0, signature.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_VerifyFinal(session, signature, baLen(signature));
+        if (log.isDebugEnabled()) log.debug(String.format("< C_VerifyFinal rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Initialises a signature verification operation, where the data is recovered from the signature.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param mechanism the verification mechanism
+     * @param key verification key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_VerifyRecoverInit(long, CKM, long)
+     */
+    static long VerifyRecoverInit(NativeProvider nativeProvider, long session, CKM mechanism, long key) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_VerifyRecoverInit session=0x%08x key=0x%08x\n  %s", session, key, mechanism));
+        long rv = nativeProvider.C_VerifyRecoverInit(session, mechanism, key);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_VerifyRecoverInit rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Verifies a signature in a single-part operation, where the data is recovered from the signature.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param signature signature to verify
+     * @param data gets signed data
+     * @param dataLen gets signed data length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_VerifyRecover(long, byte[], long, byte[], LongRef)
+     */
+    static long VerifyRecover(NativeProvider nativeProvider, long session, byte[] signature, byte[] data, LongRef dataLen) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_VerifyRecover session=0x%08x dataLen=%d\n  signature (len=%d):\n", session, dataLen.value(), signature.length));
+            Hex.dump(sb, signature, 0, signature.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_VerifyRecover(session, signature, baLen(signature), data, dataLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_VerifyRecover rv=0x%08x{%s}\n  data (len=%d):\n", rv, CKR.L2S(rv), dataLen.value()));
+            Hex.dump(sb, data, 0, (int) dataLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Continues a multiple-part digesting and encryption operation.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @param encryptedPart gets ciphertext
+     * @param encryptedPartLen get c-text length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DigestEncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static long DigestEncryptUpdate(NativeProvider nativeProvider, long session, byte[] part,
+                                           byte[] encryptedPart, LongRef encryptedPartLen) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_DigestEncryptUpdate session=0x%08x encryptedPartLen=%d\n  part (len=%d):\n", session, encryptedPartLen, part.length));
+            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_DigestEncryptUpdate(session, part, baLen(part), encryptedPart, encryptedPartLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_DigestEncryptUpdate rv=0x%08x{%s}\n  encryptedPart (len=%d):\n", rv, CKR.L2S(rv), encryptedPartLen));
+            Hex.dump(sb, encryptedPart, 0, (int) encryptedPartLen.value, "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Continues a multiple-part decryption and digesting operation.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param encryptedPart ciphertext
+     * @param part gets plaintext
+     * @param partLen gets plaintext length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DecryptDigestUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static long DecryptDigestUpdate(NativeProvider nativeProvider, long session, byte[] encryptedPart, byte[] part, LongRef partLen) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_DecryptDigestUpdate session=0x%08x partLen=%d\n  encryptedPart (len=%d):\n", session, partLen.value(), encryptedPart.length));
+            Hex.dump(sb, encryptedPart, 0, encryptedPart.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_DecryptDigestUpdate(session,
+                encryptedPart, baLen(encryptedPart), part, partLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_DecryptDigestUpdate rv=0x%08x{%s}\n  part (len=%d):\n", rv, CKR.L2S(rv), partLen.value()));
+            Hex.dump(sb, part, 0, (int) partLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Continues a multiple-part signing and encryption operation.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @param encryptedPart gets ciphertext
+     * @param encryptedPartLen gets c-text length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SignEncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static long SignEncryptUpdate(NativeProvider nativeProvider, long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_SignEncryptUdate session=0x%08x encryptedPartLen=%d\n  part (len=%d):\n", session, encryptedPartLen.value(), part.length));
+            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_SignEncryptUpdate(session, part, baLen(part),
+                encryptedPart, encryptedPartLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_SignEncryptUpdate rv=0x%08x{%s}\n  encryptedPart (len=%d):\n", rv, CKR.L2S(rv), encryptedPartLen.value()));
+            Hex.dump(sb, encryptedPart, 0, (int) encryptedPartLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Continues a multiple-part decryption and verify operation.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param encryptedPart ciphertext
+     * @param part gets plaintext
+     * @param partLen gets p-text length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DecryptVerifyUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static long DecryptVerifyUpdate(NativeProvider nativeProvider, long session, byte[] encryptedPart, byte[] part, LongRef partLen) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_DecryptVerifyUpdate session=0x%08x partLen=%d\n  encryptedPart (len=%d):\n", session, partLen.value(), encryptedPart.length));
+            Hex.dump(sb, encryptedPart, 0, encryptedPart.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_DecryptVerifyUpdate(session,
+                encryptedPart, baLen(encryptedPart), part, partLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_DecryptVerifyUpdate rv=0x%08x{%s}\n  part (len=%d):\n", rv, CKR.L2S(rv), partLen.value()));
+            Hex.dump(sb, part, 0, (int) partLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Generates a secret key, creating a new key.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param mechanism key generation mechanism
+     * @param templ template for the new key
+     * @param key gets handle of new key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GenerateKey(long, CKM, CKA[], long, LongRef)
+     */
+    static long GenerateKey(NativeProvider nativeProvider, long session, CKM mechanism, CKA[] templ, LongRef key) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_GenerateKey session=0x%08x %s\n", session, mechanism));
+            dumpTemplate(sb, templ);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_GenerateKey(session, mechanism, templ, templLen(templ), key);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_GenerateKey rv=0x%08x{%s} key=0x%08x", rv, CKR.L2S(rv), key.value()));
+        return rv;
+    }
+
+    /**
+     * Generates a public-key / private-key pair, create new key objects.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param mechanism key generation mechansim
+     * @param publicKeyTemplate template for the new public key
+     * @param privateKeyTemplate template for the new private key
+     * @param publicKey gets handle of new public key
+     * @param privateKey gets handle of new private key
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GenerateKeyPair(long, CKM, CKA[], long, CKA[], long, LongRef, LongRef)
+     */
+    static long GenerateKeyPair(NativeProvider nativeProvider, long session, CKM mechanism, CKA[] publicKeyTemplate,
+            CKA[] privateKeyTemplate, LongRef publicKey, LongRef privateKey) {
+        if (publicKey == null) {
+            publicKey = new LongRef();
+        }
+        if (privateKey == null) {
+            privateKey = new LongRef();
+        }
+
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_GenerateKeyPair session=0x%08x\n  %s", session, mechanism));
+            sb.append("\n  publicKeyTemplate:\n");
+            dumpTemplate(sb, publicKeyTemplate);
+            sb.append("\n  privateKeyTemplate:\n");
+            dumpTemplate(sb, privateKeyTemplate);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_GenerateKeyPair(session, mechanism,
+                publicKeyTemplate, templLen(publicKeyTemplate), privateKeyTemplate, templLen(privateKeyTemplate), publicKey, privateKey);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_GenerateKeyPair rv=0x%08x{%s} publicKey=0x%08x privateKey=0x%08x", rv, CKR.L2S(rv), publicKey.value(), privateKey.value()));
+        return rv;
+    }
+
+    /**
+     * Wraps (encrypts) a key.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param mechanism the wrapping mechanism
+     * @param wrappingKey wrapping key
+     * @param key key to be wrapped
+     * @param wrappedKey gets wrapped key
+     * @param wrappedKeyLen gets wrapped key length
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_WrapKey(long, CKM, long, long, byte[], LongRef)
+     */
+    static long WrapKey(NativeProvider nativeProvider, long session, CKM mechanism, long wrappingKey, long key,
+            byte[] wrappedKey, LongRef wrappedKeyLen) {
+
+        if (log.isDebugEnabled()) log.debug(String.format("> C_WrapKey session=0x%08x key=0x%08x\n  %s", session, key, mechanism));
+        long rv = nativeProvider.C_WrapKey(session, mechanism, wrappingKey,
+                key, wrappedKey, wrappedKeyLen);
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_WrapKey rv=0x%08x{%s}\n  wrappedKey (len=%d):\n", rv, CKR.L2S(rv), wrappedKeyLen.value()));
+            Hex.dump(sb, wrappedKey, 0, (int) wrappedKeyLen.value(), "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * Unwraps (decrypts) a wrapped key, creating a new key object.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param mechanism unwrapping mechanism
+     * @param unwrappingKey unwrapping key
+     * @param wrappedKey the wrapped key
+     * @param templ new key template
+     * @param key gets new handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_UnwrapKey(long, CKM, long, byte[], long, CKA[], long, LongRef)
+     */
+    static long UnwrapKey(NativeProvider nativeProvider, long session, CKM mechanism, long unwrappingKey, byte[] wrappedKey,
+                                 CKA[] templ, LongRef key) {
+
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_UnwrapKey session=0x%08x unwrappingKey=0x%08x %s\n  wrappedKey (len=%d):\n", session, unwrappingKey, mechanism, wrappedKey.length));
+            Hex.dump(sb, wrappedKey, 0, wrappedKey.length, "  ", 32, false);
+            sb.append('\n');
+            dumpTemplate(sb, templ);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_UnwrapKey(session, mechanism, unwrappingKey,
+                wrappedKey, baLen(wrappedKey), templ, templLen(templ), key);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_UnwrapKey rv=0x%08x{%s} key=0x%08x", rv, CKR.L2S(rv), key.value()));
+        return rv;
+    }
+
+    /**
+     * Derives a key from a base key, creating a new key object.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param mechanism key derivation mechanism
+     * @param baseKey base key
+     * @param templ new key template
+     * @param key ges new handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_DeriveKey(long, CKM, long, CKA[], long, LongRef)
+     */
+    static long DeriveKey(NativeProvider nativeProvider, long session, CKM mechanism, long baseKey, CKA[] templ, LongRef key) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_DeriveKey session=0x%08x baseKey=0x%08x %s\n", session, baseKey, mechanism));
+            dumpTemplate(sb, templ);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_DeriveKey(session, mechanism, baseKey, templ, templLen(templ), key);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_DeriveKey rv=0x%08x{%s} key=0x%08x", rv, CKR.L2S(rv), key.value()));
+        return rv;
+    }
+
+    /**
+     * Mixes additional seed material into the token's random number generator.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param seed the seed material
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_SeedRandom(long, byte[], long)
+     */
+    static long SeedRandom(NativeProvider nativeProvider, long session, byte[] seed) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("> C_SeedRandom session=0x%08x\n  seed (len=%d):\n", session, seed.length));
+            Hex.dump(sb, seed, 0, seed.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        long rv = nativeProvider.C_SeedRandom(session, seed, baLen(seed));
+        if (log.isDebugEnabled()) log.debug(String.format("< C_SeedRandom rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Generates random or pseudo-random data.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @param randomData receives the random data
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GenerateRandom(long, byte[], long)
+     */
+    static long GenerateRandom(NativeProvider nativeProvider, long session, byte[] randomData) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_GenerateRandom session=0x%08x randomLen=%d", session, randomData.length));
+        long rv = nativeProvider.C_GenerateRandom(session, randomData, baLen(randomData));
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(String.format("< C_GenerateRandom rv=0x%08x{%s}\n  randomData (len=%d):\n", rv, CKR.L2S(rv), randomData.length));
+            Hex.dump(sb, randomData, 0, randomData.length, "  ", 32, false);
+            log.debug(sb);
+        }
+        return rv;
+    }
+
+    /**
+     * In previous versions of Cryptoki, C_GetFunctionStatus obtained the status of a function running in parallel
+     * with an application. Now, however, C_GetFunctionStatus is a legacy function which should simply return
+     * the value CKR_FUNCTION_NOT_PARALLEL.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_GetFunctionStatus(long)
+     */
+    static long GetFunctionStatus(NativeProvider nativeProvider, long session) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_GetFunctionStatus session=0x%08x", session));
+        long rv = nativeProvider.C_GetFunctionStatus(session);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_GetFunctionStatus rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * In previous versions of Cryptoki, C_CancelFunction cancelled a function running in parallel with an application.
+     * Now, however, C_CancelFunction is a legacy function which should simply return the value
+     * CKR_FUNCTION_NOT_PARALLEL.
+     * @param nativeProvider the native provider instance
+     * @param session the session's handle
+     * @return {@link CKR} return code
+     * @see NativeProvider#C_CancelFunction(long)
+     */
+    static long CancelFunction(NativeProvider nativeProvider, long session) {
+        if (log.isDebugEnabled()) log.debug(String.format("> C_CancelFunction session=0x%08x", session));
+        long rv = nativeProvider.C_CancelFunction(session);
+        if (log.isDebugEnabled()) log.debug(String.format("< C_CancelFunction rv=0x%08x{%s}", rv, CKR.L2S(rv)));
+        return rv;
+    }
+
+    /**
+     * Return length of buf (0 if buf is null).
+     * @param buf buf
+     * @return length of buf (0 if buf is null)
+     */
+    private static int baLen(byte[] buf) {
+        return buf == null ? 0 : buf.length;
+    }
+
+    /**
+     * Return length of template (0 if template is null).
+     * @param templ template
+     * @return length of template (0 if template is null)
+     */
+    private static int templLen(CKA[] templ) {
+        return templ == null ? 0 : templ.length;
+    }
+
+    /**
+     * Dump for debug.
+     * @param sb write to
+     */
+    private static void dumpTemplate(StringBuilder sb, CKA[] template) {
+        int templateLen = templLen(template);
+        sb.append("  template (size=").append(templateLen).append(')');
+        for (int i = 0; i < templateLen; i++) {
+            sb.append("\n  ");
+            template[i].dump(sb);
+        }
+    }
+
+    /**
+     * Helper method.  Adds all public static final long fields in c to map, mapping field value to name.
+     * @param c class
+     * @return map of field value:name
+     */
+    public static Map<Long, String> createL2SMap(Class<?> c) {
+        Map<Long, String> map = new HashMap<Long, String>();
+        try {
+            for (Field f : c.getDeclaredFields()) {
+                // only put 'public static final long' in map
+                if (f.getType() == long.class && Modifier.isPublic(f.getModifiers())
+                        && Modifier.isStatic(f.getModifiers()) && Modifier.isFinal(f.getModifiers())) {
+                    map.put(f.getLong(null), f.getName());
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return map;
+    }
+
+    /**
+     * Helper method, Maps l to constant name, or value 'unknown %s constant 0x08x' % (ckx, l)'.
+     * @param map L2S map
+     * @param ckx prefix of constant type, e.g. 'CKA'
+     * @param l constant value
+     * @return constant name, or value 'unknown %s constant 0x08x' % (ckx, l)'.
+     */
+    public static String l2s(Map<Long, String> map, String ckx, long l) {
+        String s = map.get(l);
+        if (s != null) {
+            return s;
+        } else {
+          return String.format("unknown %s constant 0x%08x", ckx, l);
+        }
+    }
+
+    /**
+     * Helper method.  String format of flags.
+     * @param l2s l2s map
+     * @param flags flags
+     * @return string format of flags
+     */
+    public static String f2s(Map<Long, String> l2s, long flags) {
+        StringBuilder sb = new StringBuilder();
+        String sep = "";
+        for (int i = 63; i >= 0; i--) {
+            long mask = 1L << i;
+            if ((flags & mask) != 0) {
+                sb.append(sep);
+                sb.append(NC.l2s(l2s, "CKF", mask));
+                sep = "|";
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/pkcs11/jacknji11/NCE.java
+++ b/src/main/java/org/pkcs11/jacknji11/NCE.java
@@ -1,0 +1,1841 @@
+/*
+ * Copyright 2010-2011 Joel Hockey (joel.hockey@gmail.com). All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.pkcs11.jacknji11;
+
+/**
+ * This is the preferred java interface for calling cryptoki functions.
+ *
+ * jacknji11 provides 3 interfaces for calling cryptoki functions.
+ * <ol>
+ * <li>{@link org.pkcs11.jacknji11.NativeProvider} provides the lowest level
+ * direct mapping to the <code>'C_*'</code> functions.  There is little
+ * reason why you would ever want to invoke it directly, but you can.
+ * <li>{@link org.pkcs11.jacknji11.C} provides the exact same functions
+ * as {@link org.pkcs11.jacknji11.NativeProvider} by calling through to the
+ * corresponding native method.  The <code>'C_'</code> at the start of the
+ * function name is removed since the <code>'NC.'</code> when you call the
+ * static methods of this class looks similar.  In addition to calling
+ * the native methods, {@link org.pkcs11.jacknji11.C} provides logging
+ * through apache commons logging.  You can use this if you require fine-grain
+ * control over something such as checking
+ * {@link org.pkcs11.jacknji11.CKR} return codes.
+ * <li>{@link org.pkcs11.jacknji11.CE} (<b>C</b>ryptoki
+ * with <b>E</b>xceptions) provides the most user-friendly interface
+ * and is the preferred interface to use.  It calls
+ * related function(s) in {@link org.pkcs11.jacknji11.C},
+ * and converts any non-zero return values into a
+ * {@link org.pkcs11.jacknji11.CKRException}.  It automatically resizes
+ * arrays and other helpful things.
+ * </ol>
+ *
+ * @author Joel Hockey (joel.hockey@gmail.com)
+ */
+public class NCE {
+
+    /**
+     * Initialize cryptoki.
+     * @see NC#Initialize(NativeProvider)
+     * @see NativeProvider#C_Initialize(CK_C_INITIALIZE_ARGS)
+     */
+    static void Initialize(NativeProvider nativeProvider) {
+        long rv = NC.Initialize(nativeProvider);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Called to indicate that an application is finished with the Cryptoki library.
+     * @see NC#Finalize(NativeProvider)
+     * @see NativeProvider#C_Finalize(NativePointer)
+     */
+    static void Finalize(NativeProvider nativeProvider) {
+        long rv = NC.Finalize(nativeProvider);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Returns general information about Cryptoki.
+     * @param info location that receives information
+     * @see NC#GetInfo(NativeProvider, CK_INFO)
+     * @see NativeProvider#C_GetInfo(CK_INFO)
+     */
+    static void GetInfo(NativeProvider nativeProvider, CK_INFO info) {
+        long rv = NC.GetInfo(nativeProvider, info);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Returns general information about Cryptoki.
+     * @return info
+     * @see NC#GetInfo(NativeProvider, CK_INFO)
+     * @see NativeProvider#C_GetInfo(CK_INFO)
+     */
+    static CK_INFO GetInfo(NativeProvider nativeProvider) {
+        CK_INFO info = new CK_INFO();
+        GetInfo(nativeProvider, info);
+        return info;
+    }
+
+    /**
+     * Obtains a list of slots in the system.
+     * @param tokenPresent only slots with tokens?
+     * @param slotList receives array of slot IDs
+     * @param count receives the number of slots
+     * @see NC#GetSlotList(NativeProvider, boolean, long[], LongRef)
+     * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef)
+     */
+    static void GetSlotList(NativeProvider nativeProvider, boolean tokenPresent, long[] slotList, LongRef count) {
+        long rv = NC.GetSlotList(nativeProvider, tokenPresent, slotList, count);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Obtains a list of slots in the system.
+     * @param tokenPresent only slots with tokens?
+     * @return slot list
+     * @see NC#GetSlotList(NativeProvider, boolean, long[], LongRef)
+     * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef)
+     */
+    static long[] GetSlotList(NativeProvider nativeProvider, boolean tokenPresent) {
+        LongRef count = new LongRef();
+        GetSlotList(nativeProvider, tokenPresent, null, count);
+        long[] result = new long[(int) count.value()];
+        GetSlotList(nativeProvider, tokenPresent, result, count);
+        return result;
+    }
+
+    /**
+     * Return first slot with given label else throw CKRException.
+     * @param label label of slot to find
+     * @return slot id or CKRException if no slot found
+     * @see NC#GetSlotList(NativeProvider, boolean, long[], LongRef)
+     * @see NC#GetTokenInfo(NativeProvider, long, CK_TOKEN_INFO)
+     * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef)
+     * @see NativeProvider#C_GetTokenInfo(long, CK_TOKEN_INFO)
+     */
+    static long GetSlot(NativeProvider nativeProvider, String label) {
+        long[] allslots = GetSlotList(nativeProvider, true);
+        for (long slot : allslots) {
+            CK_TOKEN_INFO tok = GetTokenInfo(nativeProvider, slot);
+            if (tok != null && tok.label != null && new String(tok.label).trim().equals(label)) {
+                return slot;
+            }
+        }
+        throw new CKRException("No slot found with label [" + label + "]", CKR.SLOT_ID_INVALID);
+    }
+
+    /**
+     * Obtains information about a particular slot in the system.
+     * @param slotID the ID of the slot
+     * @param info receives the slot information
+     * @see NC#GetSlotInfo(NativeProvider, long, CK_SLOT_INFO)
+     * @see NativeProvider#C_GetSlotInfo(long, CK_SLOT_INFO)
+     */
+    static void GetSlotInfo(NativeProvider nativeProvider, long slotID, CK_SLOT_INFO info) {
+        long rv = NC.GetSlotInfo(nativeProvider, slotID, info);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Obtains information about a particular slot in the system.
+     * @param slotID the ID of the slot
+     * @return slot info
+     * @see NC#GetSlotInfo(NativeProvider, long, CK_SLOT_INFO)
+     * @see NativeProvider#C_GetSlotInfo(long, CK_SLOT_INFO)
+     */
+    static CK_SLOT_INFO GetSlotInfo(NativeProvider nativeProvider, long slotID) {
+        CK_SLOT_INFO info = new CK_SLOT_INFO();
+        GetSlotInfo(nativeProvider, slotID, info);
+        return info;
+    }
+
+    /**
+     * Obtains information about a particular token in the system.
+     * @param slotID ID of the token's slot
+     * @param info receives the token information
+     * @see NC#GetTokenInfo(NativeProvider, long, CK_TOKEN_INFO)
+     * @see NativeProvider#C_GetTokenInfo(long, CK_TOKEN_INFO)
+     */
+    static void GetTokenInfo(NativeProvider nativeProvider, long slotID, CK_TOKEN_INFO info) {
+        long rv = NC.GetTokenInfo(nativeProvider, slotID, info);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Obtains information about a particular token in the system.
+     * @param slotID ID of the token's slot
+     * @return token info
+     * @see NC#GetTokenInfo(NativeProvider, long, CK_TOKEN_INFO)
+     * @see NativeProvider#C_GetTokenInfo(long, CK_TOKEN_INFO)
+     */
+    static CK_TOKEN_INFO GetTokenInfo(NativeProvider nativeProvider, long slotID) {
+        CK_TOKEN_INFO info = new CK_TOKEN_INFO();
+        GetTokenInfo(nativeProvider, slotID, info);
+        return info;
+    }
+
+    /**
+     * Waits for a slot event (token insertion, removal, etc.) to occur.
+     * @param flags blocking/nonblocking flag
+     * @param slot location that receives the slot ID
+     * @param pReserved reserved.  Should be null
+     * @see NC#WaitForSlotEvent(NativeProvider, long, LongRef, NativePointer)
+     * @see NativeProvider#C_WaitForSlotEvent(long, LongRef, NativePointer)
+     */
+    static void WaitForSlotEvent(NativeProvider nativeProvider, long flags, LongRef slot, NativePointer pReserved) {
+        long rv = NC.WaitForSlotEvent(nativeProvider, flags, slot, pReserved);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Obtains a list of mechanism types supported by a token.
+     * @param slotID ID of token's slot
+     * @param mechanismList gets mechanism array
+     * @param count gets # of mechanisms
+     * @see NC#GetMechanismList(NativeProvider, long, long[], LongRef)
+     * @see NativeProvider#C_GetMechanismList(long, long[], LongRef)
+     */
+    static void GetMechanismList(NativeProvider nativeProvider, long slotID, long[] mechanismList, LongRef count) {
+        long rv = NC.GetMechanismList(nativeProvider, slotID, mechanismList, count);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Obtains a list of mechanism types supported by a token.
+     * @param slotID ID of token's slot
+     * @return mechanism list (array of {@link CKM})
+     * @see NC#GetMechanismList(NativeProvider, long, long[], LongRef)
+     * @see NativeProvider#C_GetMechanismList(long, long[], LongRef)
+     */
+    static long[] GetMechanismList(NativeProvider nativeProvider, long slotID) {
+        LongRef count = new LongRef();
+        GetMechanismList(nativeProvider, slotID, null, count);
+        long[] mechanisms = new long[(int) count.value()];
+        GetMechanismList(nativeProvider, slotID, mechanisms, count);
+        return mechanisms;
+    }
+
+    /**
+     * Obtains information about a particular mechanism possibly supported by a token.
+     * @param slotID ID of the token's slot
+     * @param type {@link CKM} type of mechanism
+     * @param info receives mechanism info
+     * @see NC#GetMechanismInfo(NativeProvider, long, long, CK_MECHANISM_INFO)
+     * @see NativeProvider#C_GetMechanismInfo(long, long, CK_MECHANISM_INFO)
+     */
+    static void GetMechanismInfo(NativeProvider nativeProvider, long slotID, long type, CK_MECHANISM_INFO info) {
+        long rv = NC.GetMechanismInfo(nativeProvider, slotID, type, info);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Obtains information about a particular mechanism possibly supported by a token.
+     * @param slotID ID of the token's slot
+     * @return mechanism info
+     * @see NC#GetMechanismInfo(NativeProvider, long, long, CK_MECHANISM_INFO)
+     * @see NativeProvider#C_GetMechanismInfo(long, long, CK_MECHANISM_INFO)
+     */
+    static CK_MECHANISM_INFO GetMechanismInfo(NativeProvider nativeProvider, long slotID, long type) {
+        CK_MECHANISM_INFO info = new CK_MECHANISM_INFO();
+        GetMechanismInfo(nativeProvider, slotID, type, info);
+        return info;
+    }
+
+    /**
+     * Initialises a token.  Pad or truncate label if required.
+     * @param slotID ID of the token's slot
+     * @param pin the SO's initial PIN
+     * @param label 32-byte token label (space padded).  If not 32 bytes, then
+     * it will be padded or truncated as required
+     * @see NC#InitToken(NativeProvider, long, byte[], byte[])
+     * @see NativeProvider#C_InitToken(long, byte[], long, byte[])
+     */
+    static void InitToken(NativeProvider nativeProvider, long slotID, byte[] pin, byte[] label) {
+        long rv = NC.InitToken(nativeProvider, slotID, pin, label);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Initialise normal user with PIN.
+     * @param session the session's handle
+     * @param pin the normal user's PIN
+     * @see NC#InitPIN(NativeProvider, long, byte[])
+     * @see NativeProvider#C_InitPIN(long, byte[], long)
+     */
+    static void InitPIN(NativeProvider nativeProvider, long session, byte[] pin) {
+        long rv = NC.InitPIN(nativeProvider, session, pin);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Change PIN.
+     * @param session the session's handle
+     * @param oldPin old PIN
+     * @param newPin new PIN
+     * @see NC#SetPIN(NativeProvider, long, byte[], byte[])
+     * @see NativeProvider#C_SetPIN(long, byte[], long, byte[], long)
+     */
+    static void SetPIN(NativeProvider nativeProvider, long session, byte[] oldPin, byte[] newPin) {
+        long rv = NC.SetPIN(nativeProvider, session, oldPin, newPin);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Opens a session between an application and a token.
+     * @param slotID the slot's ID
+     * @param flags from {@link CK_SESSION_INFO}
+     * @param application passed to callback (ok to leave it null)
+     * @param notify callback function (ok to leave it null)
+     * @param session gets session handle
+     * @see NC#OpenSession(NativeProvider, long, long, NativePointer, CK_NOTIFY, LongRef)
+     * @see NativeProvider#C_OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
+     */
+    static void OpenSession(NativeProvider nativeProvider, long slotID, long flags, NativePointer application, CK_NOTIFY notify, LongRef session) {
+        long rv = NC.OpenSession(nativeProvider, slotID, flags, application, notify, session);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Opens a session between an application and a token.
+     * @param slotID the slot's ID
+     * @param flags from {@link CK_SESSION_INFO}
+     * @param application passed to callback (ok to leave it null)
+     * @param notify callback function (ok to leave it null)
+     * @return session handle
+     * @see NC#OpenSession(NativeProvider, long, long, NativePointer, CK_NOTIFY, LongRef)
+     * @see NativeProvider#C_OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
+     */
+    static long OpenSession(NativeProvider nativeProvider, long slotID, long flags, NativePointer application, CK_NOTIFY notify) {
+        LongRef session = new LongRef();
+        OpenSession(nativeProvider, slotID, flags, application, notify, session);
+        return session.value();
+    }
+
+    /**
+     * Opens a session between an application and a token using {@link CK_SESSION_INFO#CKF_RW_SESSION and CK_SESSION_INFO#CKF_SERIAL_SESSION}
+     * and null application and notify.
+     * @param slotID the slot's ID
+     * @return session handle
+     * @see NC#OpenSession(NativeProvider, long, long, NativePointer, CK_NOTIFY, LongRef)
+     * @see NativeProvider#C_OpenSession(long, long, NativePointer, CK_NOTIFY, LongRef)
+     */
+    static long OpenSession(NativeProvider nativeProvider, long slotID) {
+        return OpenSession(nativeProvider, slotID, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+    }
+
+    /**
+     * Closes a session between an application and a token.
+     * @param session the session's handle
+     * @see NC#CloseSession(NativeProvider, long)
+     * @see NativeProvider#C_CloseSession(long)
+     */
+    static void CloseSession(NativeProvider nativeProvider, long session) {
+        long rv = NC.CloseSession(nativeProvider, session);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Closes all sessions with a token.
+     * @param slotID the token's slot
+     * @see NC#CloseAllSessions(NativeProvider, long)
+     * @see NativeProvider#C_CloseAllSessions(long)
+     */
+    static void CloseAllSessions(NativeProvider nativeProvider, long slotID) {
+        long rv = NC.CloseAllSessions(nativeProvider, slotID);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Obtains information about the session.
+     * @param session the session's handle
+     * @param info receives session info
+     * @see NC#GetSessionInfo(NativeProvider, long, CK_SESSION_INFO)
+     * @see NativeProvider#C_GetSessionInfo(long, CK_SESSION_INFO)
+     */
+    static void GetSessionInfo(NativeProvider nativeProvider, long session, CK_SESSION_INFO info) {
+        long rv = NC.GetSessionInfo(nativeProvider, session, info);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Obtains information about the session.
+     * @param session the session's handle
+     * @return session info
+     * @see NC#GetSessionInfo(NativeProvider, long, CK_SESSION_INFO)
+     * @see NativeProvider#C_GetSessionInfo(long, CK_SESSION_INFO)
+     */
+    static CK_SESSION_INFO GetSessionInfo(NativeProvider nativeProvider, long session) {
+        CK_SESSION_INFO info = new CK_SESSION_INFO();
+        GetSessionInfo(nativeProvider, session, info);
+        return info;
+    }
+
+    /**
+     * Obtains the state of the cryptographic operation.
+     * @param session the session's handle
+     * @param operationState gets state
+     * @param operationStateLen gets state length
+     * @see NC#GetOperationState(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_GetOperationState(long, byte[], LongRef)
+     */
+    static void GetOperationState(NativeProvider nativeProvider, long session, byte[] operationState, LongRef operationStateLen) {
+        long rv = NC.GetOperationState(nativeProvider, session, operationState, operationStateLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Obtains the state of the cryptographic operation.
+     * @param session the session's handle
+     * @return operation state
+     * @see NC#GetOperationState(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_GetOperationState(long, byte[], LongRef)
+     */
+    static byte[] GetOperationState(NativeProvider nativeProvider, long session) {
+        LongRef len = new LongRef();
+        GetOperationState(nativeProvider, session, null, len);
+        byte[] result = new byte[(int) len.value()];
+        GetOperationState(nativeProvider, session, result, len);
+        return resize(result, (int) len.value());
+    }
+
+    /**
+     * Restores the state of the cryptographic operation in a session.
+     * @param session the session's handle
+     * @param operationState holds state
+     * @param encryptionKey en/decryption key
+     * @param authenticationKey sign/verify key
+     * @see NC#SetOperationState(NativeProvider, long, byte[], long, long)
+     * @see NativeProvider#C_SetOperationState(long, byte[], long, long, long)
+     */
+    static void SetOperationState(NativeProvider nativeProvider, long session, byte[] operationState, long encryptionKey, long authenticationKey) {
+        long rv = NC.SetOperationState(nativeProvider, session, operationState, encryptionKey, authenticationKey);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Logs a user into a token.  Ignores CKR=0x00000100: USER_ALREADY_LOGGED_IN
+     * @param session the session's handle
+     * @param userType the user type from {@link CKU}
+     * @param pin the user's PIN
+     * @see NC#Login(NativeProvider, long, long, byte[])
+     * @see NativeProvider#C_Login(long, long, byte[], long)
+     */
+    static void Login(NativeProvider nativeProvider, long session, long userType, byte[] pin) {
+        long rv = NC.Login(nativeProvider, session, userType, pin);
+        if (rv != CKR.OK && rv != CKR.USER_ALREADY_LOGGED_IN) throw new CKRException(rv);
+    }
+
+    /**
+     * Logs a normal user into a token.
+     * @param session the session's handle
+     * @param pin the normal user's PIN
+     * @see NC#Login(NativeProvider, long, long, byte[])
+     * @see NativeProvider#C_Login(long, long, byte[], long)
+     */
+    static void LoginUser(NativeProvider nativeProvider, long session, byte[] pin) {
+        Login(nativeProvider, session, CKU.USER, pin);
+    }
+
+    /**
+     * Los a normal user into a token.
+     * @param session the session's handle
+     * @param pin the normal user's PIN encoded in a single byte encoding format such as ISO8859-1
+     * @see NC#Login(NativeProvider, long, long, byte[])
+     * @see NativeProvider#C_Login(long, long, byte[], long)
+     */
+    static void LoginUser(NativeProvider nativeProvider, long session, String pin) {
+        LoginUser(nativeProvider, session, Buf.c2b(pin));
+    }
+
+    /**
+     * Logs SO into a token.
+     * @param session the session's handle
+     * @param pin SO PIN
+     * @see NC#Login(NativeProvider, long, long, byte[])
+     * @see NativeProvider#C_Login(long, long, byte[], long)
+     */
+    static void LoginSO(NativeProvider nativeProvider, long session, byte[] pin) {
+        Login(nativeProvider, session, CKU.SO, pin);
+    }
+
+    /**
+     * Logs SO into a token.
+     * @param session the session's handle
+     * @param pin SO PIN encoded in a single byte encoding format such as ISO8859-1
+     * @see NC#Login(NativeProvider, long, long, byte[])
+     * @see NativeProvider#C_Login(long, long, byte[], long)
+     */
+    static void LoginSO(NativeProvider nativeProvider, long session, String pin) {
+        LoginSO(nativeProvider, session, Buf.c2b(pin));
+    }
+
+    /**
+     * Logs a user out from a token.
+     * @param session the session's handle
+     * @see NC#Logout(NativeProvider, long)
+     * @see NativeProvider#C_Logout(long)
+     */
+    static void Logout(NativeProvider nativeProvider, long session) {
+        long rv = NC.Logout(nativeProvider, session);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Creates a new object.
+     * @param session the session's handle
+     * @param templ the objects template
+     * @param object gets new object's handle
+     * @see NC#CreateObject(NativeProvider, long, CKA[], LongRef)
+     * @see NativeProvider#C_CreateObject(long, CKA[], long, LongRef)
+     */
+    static void CreateObject(NativeProvider nativeProvider, long session, CKA[] templ, LongRef object) {
+        long rv = NC.CreateObject(nativeProvider, session, templ, object);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Creates a new object.
+     * @param session the session's handle
+     * @return new object handle
+     * @see NC#CreateObject(NativeProvider, long, CKA[], LongRef)
+     * @see NativeProvider#C_CreateObject(long, CKA[], long, LongRef)
+     */
+    static long CreateObject(NativeProvider nativeProvider, long session, CKA... templ) {
+        LongRef object = new LongRef();
+        CreateObject(nativeProvider, session, templ, object);
+        return object.value();
+    }
+
+    /**
+     * Copies an object, creating a new object for the copy.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @param templ template for new object
+     * @param newObject receives handle of copy
+     * @see NC#CopyObject(NativeProvider, long, long, CKA[], LongRef)
+     * @see NativeProvider#C_CopyObject(long, long, CKA[], long, LongRef)
+     */
+    static void CopyObject(NativeProvider nativeProvider, long session, long object, CKA[] templ, LongRef newObject) {
+        long rv = NC.CopyObject(nativeProvider, session, object, templ, newObject);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Copies an object, creating a new object for the copy.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @param templ template for new object
+     * @return new object handle
+     * @see NC#CopyObject(NativeProvider, long, long, CKA[], LongRef)
+     * @see NativeProvider#C_CopyObject(long, long, CKA[], long, LongRef)
+     */
+    static long CopyObject(NativeProvider nativeProvider, long session, long object, CKA... templ) {
+        LongRef newObject = new LongRef();
+        CopyObject(nativeProvider, session, object, templ, newObject);
+        return newObject.value();
+    }
+
+    /**
+     * Destroys an object.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @see NC#DestroyObject(NativeProvider, long, long)
+     * @see NativeProvider#C_DestroyObject(long, long)
+     */
+    static void DestroyObject(NativeProvider nativeProvider, long session, long object) {
+        long rv = NC.DestroyObject(nativeProvider, session, object);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Gets the size of an object in bytes.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @param size receives the size of object
+     * @see NC#GetObjectSize(NativeProvider, long, long, LongRef)
+     * @see NativeProvider#C_GetObjectSize(long, long, LongRef)
+     */
+    static void GetObjectSize(NativeProvider nativeProvider, long session, long object, LongRef size) {
+        long rv = NC.GetObjectSize(nativeProvider, session, object, size);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Gets the size of an object in bytes.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @return size of object in bytes
+     * @see NC#GetObjectSize(NativeProvider, long, long, LongRef)
+     * @see NativeProvider#C_GetObjectSize(long, long, LongRef)
+     */
+    static long GetObjectSize(NativeProvider nativeProvider, long session, long object) {
+        LongRef size = new LongRef();
+        GetObjectSize(nativeProvider, session, object, size);
+        return size.value();
+    }
+
+    /**
+     * Obtains the value of one or more object attributes.
+     * @param session the session's handle
+     * @param object the objects's handle
+     * @param templ specifies attributes, gets values
+     * @see NC#GetAttributeValue(NativeProvider, long, long, CKA[])
+     * @see NativeProvider#C_GetAttributeValue(long, long, CKA[], long)
+     */
+    static void GetAttributeValue(NativeProvider nativeProvider, long session, long object, CKA... templ) {
+        if (templ == null || templ.length == 0) {
+            return;
+        }
+        long rv = NC.GetAttributeValue(nativeProvider, session, object, templ);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Obtains the value of one attributes, or returns CKA with null value if attribute doesn't exist.
+     * @param session the session's handle
+     * @param object the objects's handle
+     * @param cka {@link CKA} type
+     * @see NC#GetAttributeValue(NativeProvider, long, long, CKA[])
+     * @see NativeProvider#C_GetAttributeValue(long, long, CKA[], long)
+     */
+    static CKA GetAttributeValue(NativeProvider nativeProvider, long session, long object, long cka) {
+        CKA[] templ = {new CKA(cka)};
+        long rv = NC.GetAttributeValue(nativeProvider, session, object, templ);
+        if (rv == CKR.ATTRIBUTE_TYPE_INVALID || templ[0].ulValueLen == 0) {
+            return templ[0];
+        }
+        if (rv != CKR.OK) throw new CKRException(rv);
+
+        // allocate memory and call again
+        templ[0].pValue = new byte[(int) templ[0].ulValueLen];
+        rv = NC.GetAttributeValue(nativeProvider, session, object, templ);
+        if (rv != CKR.OK) throw new CKRException(rv);
+        return templ[0];
+    }
+
+    /**
+     * Obtains the value of one or more object attributes. Sets value to null
+     * if object does not include attribute.
+     * @param session the session's handle
+     * @param object the objects's handle
+     * @param types {@link CKA} attribute types to get
+     * @return attribute values
+     * @see NC#GetAttributeValue(NativeProvider, long, long, CKA[])
+     * @see NativeProvider#C_GetAttributeValue(long, long, CKA[], long)
+     */
+    static CKA[] GetAttributeValue(NativeProvider nativeProvider, long session, long object, long... types) {
+        if (types == null || types.length == 0) {
+            return new CKA[0];
+        }
+        CKA[] templ = new CKA[types.length];
+        for (int i = 0; i < types.length; i++) {
+            templ[i] = new CKA(types[i], null);
+        }
+
+        // try getting all at once
+        try {
+            GetAttributeValue(nativeProvider, session, object, templ);
+            // allocate memory and go again
+            for (CKA att : templ) {
+                att.pValue = att.ulValueLen > 0 ? new byte[(int) att.ulValueLen] : null;
+            }
+            GetAttributeValue(nativeProvider, session, object, templ);
+            return templ;
+        } catch (CKRException ckre) {
+            // if we got CKR_ATTRIBUTE_TYPE_INVALID, then handle below
+            if (ckre.getCKR() != CKR.ATTRIBUTE_TYPE_INVALID) {
+                throw ckre;
+            }
+        }
+
+        // send gets one at a time
+        CKA[] result = new CKA[types.length];
+        for (int i = 0; i < types.length; i++) {
+            result[i] = GetAttributeValue(nativeProvider, session, object, types[i]);
+        }
+        return result;
+    }
+
+    /**
+     * Modifies the values of one or more object attributes.
+     * @param session the session's handle
+     * @param object the object's handle
+     * @param templ specifies attributes and values
+     * @see NC#SetAttributeValue(NativeProvider, long, long, CKA[])
+     * @see NativeProvider#C_SetAttributeValue(long, long, CKA[], long)
+     */
+    static void SetAttributeValue(NativeProvider nativeProvider, long session, long object, CKA... templ) {
+        long rv = NC.SetAttributeValue(nativeProvider, session, object, templ);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Initialises a search for token and session objects that match a template.
+     * @param session the session's handle
+     * @param templ attribute values to match
+     * @see NC#FindObjectsInit(NativeProvider, long, CKA[])
+     * @see NativeProvider#C_FindObjectsInit(long, CKA[], long)
+     */
+    static void FindObjectsInit(NativeProvider nativeProvider, long session, CKA... templ) {
+        long rv = NC.FindObjectsInit(nativeProvider, session, templ);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Continues a search for token and session objects that match a template,
+     * obtaining additional object handles.
+     * @param session the session's handle
+     * @param found gets object handles
+     * @param objectCount number of object handles returned
+     * @see NC#FindObjects(NativeProvider, long, long[], LongRef)
+     * @see NativeProvider#C_FindObjects(long, long[], long, LongRef)
+     */
+    static void FindObjects(NativeProvider nativeProvider, long session, long[] found, LongRef objectCount) {
+        long rv = NC.FindObjects(nativeProvider, session, found, objectCount);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Continues a search for token and session objects that match a template,
+     * obtaining additional object handles.
+     * @param session the session's handle
+     * @param maxObjects maximum objects to return
+     * @return list of object handles
+     * @see NC#FindObjects(NativeProvider, long, long[], LongRef)
+     * @see NativeProvider#C_FindObjects(long, long[], long, LongRef)
+     */
+    static long[] FindObjects(NativeProvider nativeProvider, long session, int maxObjects) {
+        long[] found = new long[maxObjects];
+        LongRef len = new LongRef();
+        FindObjects(nativeProvider, session, found, len);
+        long count = len.value();
+        if (count == maxObjects) {
+            return found;
+        } else {
+            long[] result = new long[(int) count];
+            System.arraycopy(found, 0, result, 0, result.length);
+            return result;
+        }
+    }
+
+    /**
+     * Finishes a search for token and session objects.
+     * @param session the session's handle
+     * @see NC#FindObjectsFinal(NativeProvider, long)
+     * @see NativeProvider#C_FindObjectsFinal(long)
+     */
+    static void FindObjectsFinal(NativeProvider nativeProvider, long session) {
+        long rv = NC.FindObjectsFinal(nativeProvider, session);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Single-part search for token and session objects that match a template.
+     * @param session the session's handle
+     * @param templ attribute values to match
+     * @return all objects matching
+     * @see NC#FindObjectsInit(NativeProvider, long, CKA[])
+     * @see NativeProvider#C_FindObjectsInit(long, CKA[], long)
+     */
+    static long[] FindObjects(NativeProvider nativeProvider, long session, CKA... templ) {
+        FindObjectsInit(nativeProvider, session, templ);
+        int maxObjects = 1024;
+        // call once
+        long[] result = FindObjects(nativeProvider, session, maxObjects);
+        // most likely we are done now
+        if (result.length < maxObjects) {
+            FindObjectsFinal(nativeProvider, session);
+            return result;
+        }
+
+        // this is a lot of objects!
+        while (true) {
+            maxObjects *= 2;
+            long[] found = FindObjects(nativeProvider, session, maxObjects);
+            long[] temp = new long[result.length + found.length];
+            System.arraycopy(result, 0, temp, 0, result.length);
+            System.arraycopy(found, 0, temp, result.length, found.length);
+            result = temp;
+            if (found.length < maxObjects) { // exhausted
+                FindObjectsFinal(nativeProvider, session);
+                return result;
+            }
+        }
+    }
+
+    /**
+     * Initialises an encryption operation.
+     * @param session the session's handle
+     * @param mechanism the encryption mechanism
+     * @param key handle of encryption key
+     * @see NC#EncryptInit(NativeProvider, long, CKM, long)
+     * @see NativeProvider#C_EncryptInit(long, CKM, long)
+     */
+    static void EncryptInit(NativeProvider nativeProvider, long session, CKM mechanism, long key) {
+        long rv = NC.EncryptInit(nativeProvider, session, mechanism, key);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Encrypts single-part data.
+     * @param session the session's handle
+     * @param data the plaintext data
+     * @param encryptedData gets ciphertext
+     * @param encryptedDataLen gets c-text size
+     * @see NC#Encrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     */
+    static void Encrypt(NativeProvider nativeProvider, long session, byte[] data, byte[] encryptedData, LongRef encryptedDataLen) {
+        long rv = NC.Encrypt(nativeProvider, session, data, encryptedData, encryptedDataLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Encrypts single-part data with 2 calls.  First call determines
+     * size of result which may include padding, second call does encrypt.
+     * @param session the session's handle
+     * @param data the plaintext data
+     * @return encrypted data
+     * @see NC#Encrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] EncryptPad(NativeProvider nativeProvider, long session, byte[] data) {
+        LongRef l = new LongRef();
+        Encrypt(nativeProvider, session, data, null, l);
+        byte[] result = new byte[(int) l.value()];
+        Encrypt(nativeProvider, session, data, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Encrypts single-part data with single call assuming result
+     * has no padding and is same size as input.
+     * @param session the session's handle
+     * @param data the plaintext data
+     * @return encrypted data
+     * @see NC#Encrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] Encrypt(NativeProvider nativeProvider, long session, byte[] data) {
+        byte[] result = new byte[data.length];
+        LongRef l = new LongRef(result.length);
+        Encrypt(nativeProvider, session, data, result, l);
+        return resize(result, (int) l.value);
+    }
+
+    /**
+     * Continues a multiple-part encryption.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @param encryptedPart get ciphertext
+     * @param encryptedPartLen gets c-text size
+     * @see NC#EncryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_EncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static void EncryptUpdate(NativeProvider nativeProvider, long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
+        long rv = NC.EncryptUpdate(nativeProvider, session, part, encryptedPart, encryptedPartLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Continues a multiple-part encryption.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @return encrypted part
+     * @see NC#EncryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_EncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] EncryptUpdate(NativeProvider nativeProvider, long session, byte[] part) {
+        LongRef l = new LongRef();
+        EncryptUpdate(nativeProvider, session, part, null, l);
+        byte[] result = new byte[(int) l.value()];
+        EncryptUpdate(nativeProvider, session, part, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Finishes a multiple-part encryption.
+     * @param session the session's handle
+     * @param lastEncryptedPart last c-text
+     * @param lastEncryptedPartLen gets last size
+     * @see NC#EncryptFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_EncryptFinal(long, byte[], LongRef)
+     */
+    static void EncryptFinal(NativeProvider nativeProvider, long session, byte[] lastEncryptedPart, LongRef lastEncryptedPartLen) {
+        long rv = NC.EncryptFinal(nativeProvider, session, lastEncryptedPart, lastEncryptedPartLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Finishes a multiple-part encryption.
+     * @param session the session's handle
+     * @return last encrypted part
+     * @see NC#EncryptFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_EncryptFinal(long, byte[], LongRef)
+     */
+    static byte[] EncryptFinal(NativeProvider nativeProvider, long session) {
+        LongRef l = new LongRef();
+        EncryptFinal(nativeProvider, session, null, l);
+        byte[] result = new byte[(int) l.value()];
+        EncryptFinal(nativeProvider, session, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Encrypts single-part data with 2 calls.  First call determines
+     * size of result which may include padding, second call does encrypt.
+     * @param session the session's handle
+     * @param mechanism the encryption mechanism
+     * @param key handle of encryption key
+     * @param data the plaintext data
+     * @return encrypted data
+     * @see NC#Encrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] EncryptPad(NativeProvider nativeProvider, long session, CKM mechanism, long key, byte[] data) {
+        EncryptInit(nativeProvider, session, mechanism, key);
+        return EncryptPad(nativeProvider, session, data);
+    }
+
+    /**
+     * Encrypts single-part data with single call assuming result
+     * has no padding and is same size as input.
+     * @param session the session's handle
+     * @param mechanism the encryption mechanism
+     * @param key handle of encryption key
+     * @param data the plaintext data
+     * @return encrypted data
+     * @see NC#Encrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Encrypt(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] Encrypt(NativeProvider nativeProvider, long session, CKM mechanism, long key, byte[] data) {
+        EncryptInit(nativeProvider, session, mechanism, key);
+        return Encrypt(nativeProvider, session, data);
+    }
+
+    /**
+     * Initialises a decryption operation.
+     * @param session the session's handle
+     * @param mechanism the decryption mechanism
+     * @param key handle of decryption key
+     * @see NC#DecryptInit(NativeProvider, long, CKM, long)
+     * @see NativeProvider#C_DecryptInit(long, CKM, long)
+     */
+    static void DecryptInit(NativeProvider nativeProvider, long session, CKM mechanism, long key) {
+        long rv = NC.DecryptInit(nativeProvider, session, mechanism, key);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Decrypts encrypted data in a single part.
+     * @param session the session's handle
+     * @param encryptedData cipertext
+     * @param data gets plaintext
+     * @param dataLen gets p-text size
+     * @see NC#Decrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     */
+    static void Decrypt(NativeProvider nativeProvider, long session, byte[] encryptedData, byte[] data, LongRef dataLen) {
+        long rv = NC.Decrypt(nativeProvider, session, encryptedData, data, dataLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Decrypts encrypted data in a single-part with 2 calls.  First call determines
+     * size of result which may have padding removed, second call does decrypt.
+     * @param session the session's handle
+     * @param encryptedData cipertext
+     * @return plaintext
+     * @see NC#Decrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] DecryptPad(NativeProvider nativeProvider, long session, byte[] encryptedData) {
+        LongRef l = new LongRef();
+        Decrypt(nativeProvider, session, encryptedData, null, l);
+        byte[] result = new byte[(int) l.value()];
+        Decrypt(nativeProvider, session, encryptedData, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Decrypts encrypted data in a single-part with 1 single call
+     * assuming result is not larger than input.
+     * @param session the session's handle
+     * @param encryptedData ciphertext
+     * @return plaintext
+     * @see NC#Decrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] Decrypt(NativeProvider nativeProvider, long session, byte[] encryptedData) {
+        byte[] result = new byte[encryptedData.length];
+        LongRef l = new LongRef(result.length);
+        Decrypt(nativeProvider, session, encryptedData, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Continues a multiple-part decryption.
+     * @param session the session's handle
+     * @param encryptedPart encrypted data
+     * @param data gets plaintext
+     * @param dataLen get p-text size
+     * @see NC#DecryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_DecryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static void DecryptUpdate(NativeProvider nativeProvider, long session, byte[] encryptedPart, byte[] data, LongRef dataLen) {
+        long rv = NC.DecryptUpdate(nativeProvider, session, encryptedPart, data, dataLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Continues a multiple-part decryption.
+     * @param session the session's handle
+     * @param encryptedPart encrypted data
+     * @return plaintext
+     * @see NC#DecryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_DecryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] DecryptUpdate(NativeProvider nativeProvider, long session, byte[] encryptedPart) {
+        LongRef l = new LongRef();
+        DecryptUpdate(nativeProvider, session, encryptedPart, null, l);
+        byte[] result = new byte[(int) l.value()];
+        DecryptUpdate(nativeProvider, session, encryptedPart, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Finishes a multiple-part decryption.
+     * @param session the session's handle
+     * @param lastPart gets plaintext
+     * @param lastPartLen p-text size
+     * @see NC#DecryptFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_DecryptFinal(long, byte[], LongRef)
+     */
+    static void DecryptFinal(NativeProvider nativeProvider, long session, byte[] lastPart, LongRef lastPartLen) {
+        long rv = NC.DecryptFinal(nativeProvider, session, lastPart, lastPartLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Finishes a multiple-part decryption.
+     * @param session the session's handle
+     * @return last part of plaintext
+     * @see NC#DecryptFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_DecryptFinal(long, byte[], LongRef)
+     */
+    static byte[] DecryptFinal(NativeProvider nativeProvider, long session) {
+        LongRef l = new LongRef();
+        DecryptFinal(nativeProvider, session, null, l);
+        byte[] result = new byte[(int) l.value()];
+        DecryptFinal(nativeProvider, session, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Decrypts encrypted data in a single-part with 2 calls.  First call determines
+     * size of result which may have padding removed, second call does decrypt.
+     * @param session the session's handle
+     * @param mechanism the decryption mechanism
+     * @param key handle of decryption key
+     * @param encryptedData cipertext
+     * @return plaintext
+     * @see NC#Decrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] DecryptPad(NativeProvider nativeProvider, long session, CKM mechanism, long key, byte[] encryptedData) {
+        DecryptInit(nativeProvider, session, mechanism, key);
+        return DecryptPad(nativeProvider, session, encryptedData);
+    }
+
+    /**
+     * Decrypts encrypted data in a single-part with 1 single call
+     * assuming result is not larger than input.
+     * @param session the session's handle
+     * @param mechanism the decryption mechanism
+     * @param key handle of decryption key
+     * @param encryptedData cipertext
+     * @return plaintext
+     * @see NC#Decrypt(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Decrypt(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] Decrypt(NativeProvider nativeProvider, long session, CKM mechanism, long key, byte[] encryptedData) {
+        DecryptInit(nativeProvider, session, mechanism, key);
+        return Decrypt(nativeProvider, session, encryptedData);
+    }
+
+    /**
+     * Initialises a message-digesting operation.
+     * @param session the session's handle
+     * @param mechanism the digesting mechanism
+     * @see NC#DigestInit(NativeProvider, long, CKM)
+     * @see NativeProvider#C_DigestInit(long, CKM)
+     */
+    static void DigestInit(NativeProvider nativeProvider, long session, CKM mechanism) {
+        long rv = NC.DigestInit(nativeProvider, session, mechanism);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Digests data in a single part.
+     * @param session the session's handle
+     * @param data data to be digested
+     * @param digest gets the message digest
+     * @param digestLen gets digest length
+     * @see NC#Digest(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Digest(long, byte[], long, byte[], LongRef)
+     */
+    static void Digest(NativeProvider nativeProvider, long session, byte[] data, byte[] digest, LongRef digestLen) {
+        long rv = NC.Digest(nativeProvider, session, data, digest, digestLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Digests data in a single part.
+     * @param session the session's handle
+     * @param data data to be digested
+     * @return digest
+     * @see NC#Digest(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Digest(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] Digest(NativeProvider nativeProvider, long session, byte[] data) {
+        LongRef l = new LongRef();
+        Digest(nativeProvider, session, data, null, l);
+        byte[] result = new byte[(int) l.value()];
+        Digest(nativeProvider, session, data, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Continues a multiple-part message-digesting.
+     * @param session the session's handle
+     * @param part data to be digested
+     * @see NC#DigestUpdate(NativeProvider, long, byte[])
+     * @see NativeProvider#C_DigestUpdate(long, byte[], long)
+     */
+    static void DigestUpdate(NativeProvider nativeProvider, long session, byte[] part) {
+        long rv = NC.DigestUpdate(nativeProvider, session, part);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Continues a multi-part message-digesting operation, by digesting
+     * the value of a secret key as part of the data already digested.
+     * @param session the session's handle
+     * @param key secret key to digest
+     * @see NC#DigestKey(NativeProvider, long, long)
+     * @see NativeProvider#C_DigestKey(long, long)
+     */
+    static void DigestKey(NativeProvider nativeProvider, long session, long key) {
+        long rv = NC.DigestKey(nativeProvider, session, key);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Finishes a multiple-part message-digesting operation.
+     * @param session the session's handle
+     * @param digest gets the message digest
+     * @param digestLen gets byte count of digest
+     * @see NC#DigestFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_DigestFinal(long, byte[], LongRef)
+     */
+    static void DigestFinal(NativeProvider nativeProvider, long session, byte[] digest, LongRef digestLen) {
+        long rv = NC.DigestFinal(nativeProvider, session, digest, digestLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Finishes a multiple-part message-digesting operation.
+     * @param session the session's handle
+     * @return digest
+     * @see NC#DigestFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_DigestFinal(long, byte[], LongRef)
+     */
+    static byte[] DigestFinal(NativeProvider nativeProvider, long session) {
+        LongRef l = new LongRef();
+        DigestFinal(nativeProvider, session, null, l);
+        byte[] result = new byte[(int) l.value()];
+        DigestFinal(nativeProvider, session, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Digests data in a single part.
+     * @param session the session's handle
+     * @param mechanism the digesting mechanism
+     * @param data data to be digested
+     * @return digest
+     * @see NC#Digest(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Digest(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] Digest(NativeProvider nativeProvider, long session, CKM mechanism, byte[] data) {
+        DigestInit(nativeProvider, session, mechanism);
+        return Digest(nativeProvider, session, data);
+    }
+
+    /**
+     * Initialises a signature (private key encryption) operation, where
+     * the signature is (will be) an appendix to the data, and plaintext
+     * cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the signature mechanism
+     * @param key handle of signature key
+     * @see NC#SignInit(NativeProvider, long, CKM, long)
+     * @see NativeProvider#C_SignInit(long, CKM, long)
+     */
+    static void SignInit(NativeProvider nativeProvider, long session, CKM mechanism, long key) {
+        long rv = NC.SignInit(nativeProvider, session, mechanism, key);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Signs (encrypts with private key) data in a single part, where the signature is (will be)
+     * an appendix to the data, and plaintext cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param data the data to sign
+     * @param signature gets the signature
+     * @param signatureLen gets signature length
+     * @see NC#Sign(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Sign(long, byte[], long, byte[], LongRef)
+     */
+    static void Sign(NativeProvider nativeProvider, long session, byte[] data, byte[] signature, LongRef signatureLen) {
+        long rv = NC.Sign(nativeProvider, session, data, signature, signatureLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Signs (encrypts with private key) data in a single part, where the signature is (will be)
+     * an appendix to the data, and plaintext cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param data the data to sign
+     * @return signature
+     * @see NC#Sign(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Sign(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] Sign(NativeProvider nativeProvider, long session, byte[] data) {
+        LongRef l = new LongRef();
+        Sign(nativeProvider, session, data, null, l);
+        byte[] result = new byte[(int) l.value()];
+        Sign(nativeProvider, session, data, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Continues a multiple-part signature operation where the signature is
+     * (will be) an appendix to the data, and plaintext cannot be recovered from
+     * the signature.
+     * @param session the session's handle
+     * @param part data to sign
+     * @see NC#SignUpdate(NativeProvider, long, byte[])
+     * @see NativeProvider#C_SignUpdate(long, byte[], long)
+     */
+    static void SignUpdate(NativeProvider nativeProvider, long session, byte[] part) {
+        long rv = NC.SignUpdate(nativeProvider, session, part);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Finishes a multiple-part signature operation, returning the signature.
+     * @param session the session's handle
+     * @param signature gets the signature
+     * @param signatureLen gets signature length
+     * @see NC#SignFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_SignFinal(long, byte[], LongRef)
+     */
+    static void SignFinal(NativeProvider nativeProvider, long session, byte[] signature, LongRef signatureLen) {
+        long rv = NC.SignFinal(nativeProvider, session, signature, signatureLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Finishes a multiple-part signature operation, returning the signature.
+     * @param session the session's handle
+     * @return signature
+     * @see NC#SignFinal(NativeProvider, long, byte[], LongRef)
+     * @see NativeProvider#C_SignFinal(long, byte[], LongRef)
+     */
+    static byte[] SignFinal(NativeProvider nativeProvider, long session) {
+        LongRef l = new LongRef();
+        SignFinal(nativeProvider, session, null, l);
+        byte[] result = new byte[(int) l.value()];
+        SignFinal(nativeProvider, session, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Signs (encrypts with private key) data in a single part, where the signature is (will be)
+     * an appendix to the data, and plaintext cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the signature mechanism
+     * @param key handle of signature key
+     * @param data the data to sign
+     * @return signature
+     * @see NC#Sign(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_Sign(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] Sign(NativeProvider nativeProvider, long session, CKM mechanism, long key, byte[] data) {
+        SignInit(nativeProvider, session, mechanism, key);
+        return Sign(nativeProvider, session, data);
+    }
+
+    /**
+     * Initialises a signature operation, where the data can be recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the signature mechanism
+     * @param key handle f the signature key
+     * @see NC#SignRecoverInit(NativeProvider, long, CKM, long)
+     * @see NativeProvider#C_SignRecoverInit(long, CKM, long)
+     */
+    static void SignRecoverInit(NativeProvider nativeProvider, long session, CKM mechanism, long key) {
+        long rv = NC.SignRecoverInit(nativeProvider, session, mechanism, key);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Signs data in a single operation, where the data can be recovered from the signature.
+     * @param session the session's handle
+     * @param data the data to sign
+     * @param signature gets the signature
+     * @param signatureLen gets signature length
+     * @see NC#SignRecover(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_SignRecover(long, byte[], long, byte[], LongRef)
+     */
+    static void SignRecover(NativeProvider nativeProvider, long session, byte[] data, byte[] signature, LongRef signatureLen) {
+        long rv = NC.SignRecover(nativeProvider, session, data, signature, signatureLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Signs data in a single operation, where the data can be recovered from the signature.
+     * @param session the session's handle
+     * @param data the data to sign
+     * @return signature
+     * @see NC#SignRecover(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_SignRecover(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] SignRecover(NativeProvider nativeProvider, long session, byte[] data) {
+        LongRef l = new LongRef();
+        SignRecover(nativeProvider, session, data, null, l);
+        byte[] result = new byte[(int) l.value()];
+        SignRecover(nativeProvider, session, data, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Signs data in a single operation, where the data can be recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the signature mechanism
+     * @param key handle f the signature key
+     * @param data the data to sign
+     * @return signature
+     * @see NC#SignRecover(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_SignRecover(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] SignRecover(NativeProvider nativeProvider, long session, CKM mechanism, long key, byte[] data) {
+        SignRecoverInit(nativeProvider, session, mechanism, key);
+        return SignRecover(nativeProvider, session, data);
+    }
+
+    /**
+     * Initialises a verification operation, where the signature is an appendix to the data,
+     * and plaintext cannot be recovered from the signature (e.g. DSA).
+     * @param session the session's handle
+     * @param mechanism the verification mechanism
+     * @param key verification key
+     * @see NC#VerifyInit(NativeProvider, long, CKM, long)
+     * @see NativeProvider#C_VerifyInit(long, CKM, long)
+     */
+    static void VerifyInit(NativeProvider nativeProvider, long session, CKM mechanism, long key) {
+        long rv = NC.VerifyInit(nativeProvider, session, mechanism, key);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Verifies a signature in a single-part operation, where the signature is an appendix to the data,
+     * and plaintext cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param data signed data
+     * @param signature signature
+     * @see NC#Verify(NativeProvider, long, byte[], byte[])
+     * @see NativeProvider#C_Verify(long, byte[], long, byte[], long)
+     */
+    static void Verify(NativeProvider nativeProvider, long session, byte[] data, byte[] signature) {
+        long rv = NC.Verify(nativeProvider, session, data, signature);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Continues a multiple-part verification operation where the signature is an appendix to the data,
+     * and plaintext cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param part signed data
+     * @see NC#VerifyUpdate(NativeProvider, long, byte[])
+     * @see NativeProvider#C_VerifyUpdate(long, byte[], long)
+     */
+    static void VerifyUpdate(NativeProvider nativeProvider, long session, byte[] part) {
+        long rv = NC.VerifyUpdate(nativeProvider, session, part);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Finishes a multiple-part verification operation, checking the signature.
+     * @param session the session's handle
+     * @param signature signature to verify
+     * @see NC#VerifyFinal(NativeProvider, long, byte[])
+     * @see NativeProvider#C_VerifyFinal(long, byte[], long)
+     */
+    static void VerifyFinal(NativeProvider nativeProvider, long session, byte[] signature) {
+        long rv = NC.VerifyFinal(nativeProvider, session, signature);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Verifies a signature in a single-part operation, where the signature is an appendix to the data,
+     * and plaintext cannot be recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the verification mechanism
+     * @param key verification key
+     * @param data signed data
+     * @param signature signature
+     * @see NC#Verify(NativeProvider, long, byte[], byte[])
+     * @see NativeProvider#C_Verify(long, byte[], long, byte[], long)
+     */
+    static void Verify(NativeProvider nativeProvider, long session, CKM mechanism, long key, byte[] data, byte[] signature) {
+        VerifyInit(nativeProvider, session, mechanism, key);
+        Verify(nativeProvider, session, data, signature);
+    }
+
+    /**
+     * Initialises a signature verification operation, where the data is recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the verification mechanism
+     * @param key verification key
+     * @see NC#VerifyRecoverInit(NativeProvider, long, CKM, long)
+     * @see NativeProvider#C_VerifyRecoverInit(long, CKM, long)
+     */
+    static void VerifyRecoverInit(NativeProvider nativeProvider, long session, CKM mechanism, long key) {
+        long rv = NC.VerifyRecoverInit(nativeProvider, session, mechanism, key);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Verifies a signature in a single-part operation, where the data is recovered from the signature.
+     * @param session the session's handle
+     * @param signature signature to verify
+     * @param data gets signed data
+     * @param dataLen gets signed data length
+     * @see NC#VerifyRecover(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_VerifyRecover(long, byte[], long, byte[], LongRef)
+     */
+    static void VerifyRecover(NativeProvider nativeProvider, long session, byte[] signature, byte[] data, LongRef dataLen) {
+        long rv = NC.VerifyRecover(nativeProvider, session, signature, data, dataLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Verifies a signature in a single-part operation, where the data is recovered from the signature.
+     * @param session the session's handle
+     * @param signature signature to verify
+     * @return data
+     * @see NC#VerifyRecover(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_VerifyRecover(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] VerifyRecover(NativeProvider nativeProvider, long session, byte[] signature) {
+        LongRef l = new LongRef();
+        VerifyRecover(nativeProvider, session, signature, null, l);
+        byte[] result = new byte[(int) l.value()];
+        VerifyRecover(nativeProvider, session, signature, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Verifies a signature in a single-part operation, where the data is recovered from the signature.
+     * @param session the session's handle
+     * @param mechanism the verification mechanism
+     * @param key verification key
+     * @param signature signature to verify
+     * @return data
+     * @see NC#VerifyRecover(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_VerifyRecover(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] VerifyRecover(NativeProvider nativeProvider, long session, CKM mechanism, long key, byte[] signature) {
+        VerifyRecoverInit(nativeProvider, session, mechanism, key);
+        return VerifyRecover(nativeProvider, session, signature);
+    }
+
+    /**
+     * Continues a multiple-part digesting and encryption operation.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @param encryptedPart gets ciphertext
+     * @param encryptedPartLen get c-text length
+     * @see NC#DigestEncryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_DigestEncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static void DigestEncryptUpdate(NativeProvider nativeProvider, long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
+        long rv = NC.DigestEncryptUpdate(nativeProvider, session, part, encryptedPart, encryptedPartLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Continues a multiple-part digesting and encryption operation.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @return encrypted part
+     * @see NC#DigestEncryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_DigestEncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] DigestEncryptUpdate(NativeProvider nativeProvider, long session, byte[] part) {
+        LongRef l = new LongRef();
+        DigestEncryptUpdate(nativeProvider, session, part, null, l);
+        byte[] result = new byte[(int) l.value()];
+        DigestEncryptUpdate(nativeProvider, session, part, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Continues a multiple-part decryption and digesting operation.
+     * @param session the session's handle
+     * @param encryptedPart ciphertext
+     * @param part gets plaintext
+     * @param partLen gets plaintext length
+     * @see NC#DigestUpdate(NativeProvider, long, byte[])
+     * @see NativeProvider#C_DigestUpdate(long, byte[], long)
+     */
+    static void DecryptDigestUpdate(NativeProvider nativeProvider, long session, byte[] encryptedPart, byte[] part, LongRef partLen) {
+        long rv = NC.DecryptDigestUpdate(nativeProvider, session, encryptedPart, part, partLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Continues a multiple-part decryption and digesting operation.
+     * @param session the session's handle
+     * @param encryptedPart ciphertext
+     * @return plaintext
+     * @see NC#DecryptDigestUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_DecryptDigestUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] DecryptDigestUpdate(NativeProvider nativeProvider, long session, byte[] encryptedPart) {
+        LongRef l = new LongRef();
+        DecryptDigestUpdate(nativeProvider, session, encryptedPart, null, l);
+        byte[] result = new byte[(int) l.value()];
+        DecryptDigestUpdate(nativeProvider, session, encryptedPart, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Continues a multiple-part signing and encryption operation.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @param encryptedPart gets ciphertext
+     * @param encryptedPartLen gets c-text length
+     * @see NC#SignEncryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_SignEncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static void SignEncryptUpdate(NativeProvider nativeProvider, long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
+        long rv = NC.SignEncryptUpdate(nativeProvider, session, part, encryptedPart, encryptedPartLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Continues a multiple-part signing and encryption operation.
+     * @param session the session's handle
+     * @param part the plaintext data
+     * @return encrypted part
+     * @see NC#SignEncryptUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_SignEncryptUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] SignEncryptUpdate(NativeProvider nativeProvider, long session, byte[] part) {
+        LongRef l = new LongRef();
+        SignEncryptUpdate(nativeProvider, session, part, null, l);
+        byte[] result = new byte[(int) l.value()];
+        SignEncryptUpdate(nativeProvider, session, part, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Continues a multiple-part decryption and verify operation.
+     * @param session the session's handle
+     * @param encryptedPart ciphertext
+     * @param part gets plaintext
+     * @param partLen gets p-text length
+     * @see NC#DecryptVerifyUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_DecryptVerifyUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static void DecryptVerifyUpdate(NativeProvider nativeProvider, long session, byte[] encryptedPart, byte[] part, LongRef partLen) {
+        long rv = NC.DecryptVerifyUpdate(nativeProvider, session, encryptedPart, part, partLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Continues a multiple-part decryption and verify operation.
+     * @param session the session's handle
+     * @param encryptedPart ciphertext
+     * @return plaintext
+     * @see NC#DecryptVerifyUpdate(NativeProvider, long, byte[], byte[], LongRef)
+     * @see NativeProvider#C_DecryptVerifyUpdate(long, byte[], long, byte[], LongRef)
+     */
+    static byte[] DecryptVerifyUpdate(NativeProvider nativeProvider, long session, byte[] encryptedPart) {
+        LongRef l = new LongRef();
+        DecryptVerifyUpdate(nativeProvider, session, encryptedPart, null, l);
+        byte[] result = new byte[(int) l.value()];
+        DecryptVerifyUpdate(nativeProvider, session, encryptedPart, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Generates a secret key, creating a new key.
+     * @param session the session's handle
+     * @param mechanism key generation mechanism
+     * @param templ template for the new key
+     * @param key gets handle of new key
+     * @see NC#GenerateKey(NativeProvider, long, CKM, CKA[], LongRef)
+     * @see NativeProvider#C_GenerateKey(long, CKM, CKA[], long, LongRef)
+     */
+    static void GenerateKey(NativeProvider nativeProvider, long session, CKM mechanism, CKA[] templ, LongRef key) {
+        long rv = NC.GenerateKey(nativeProvider, session, mechanism, templ, key);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Generates a secret key, creating a new key.
+     * @param session the session's handle
+     * @param mechanism key generation mechanism
+     * @param templ template for the new key
+     * @return key handle
+     * @see NC#GenerateKey(NativeProvider, long, CKM, CKA[], LongRef)
+     * @see NativeProvider#C_GenerateKey(long, CKM, CKA[], long, LongRef)
+     */
+    static long GenerateKey(NativeProvider nativeProvider, long session, CKM mechanism, CKA... templ) {
+        LongRef key = new LongRef();
+        GenerateKey(nativeProvider, session, mechanism, templ, key);
+        return key.value();
+    }
+
+    /**
+     * Generates a public-key / private-key pair, create new key objects.
+     * @param session the session's handle
+     * @param mechanism key generation mechanism
+     * @param publicKeyTemplate template for the new public key
+     * @param privateKeyTemplate template for the new private key
+     * @param publicKey gets handle of new public key
+     * @param privateKey gets handle of new private key
+     * @see NC#GenerateKeyPair(NativeProvider, long, CKM, CKA[], CKA[], LongRef, LongRef)
+     * @see NativeProvider#C_GenerateKeyPair(long, CKM, CKA[], long, CKA[], long, LongRef, LongRef)
+     */
+    static void GenerateKeyPair(NativeProvider nativeProvider, long session, CKM mechanism, CKA[] publicKeyTemplate, CKA[] privateKeyTemplate,
+                                LongRef publicKey, LongRef privateKey) {
+        long rv = NC.GenerateKeyPair(nativeProvider, session, mechanism, publicKeyTemplate, privateKeyTemplate, publicKey, privateKey);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Wraps (encrypts) a key.
+     * @param session the session's handle
+     * @param mechanism the wrapping mechanism
+     * @param wrappingKey wrapping key
+     * @param key key to be wrapped
+     * @param wrappedKey gets wrapped key
+     * @param wrappedKeyLen gets wrapped key length
+     * @see NC#WrapKey(NativeProvider, long, CKM, long, long, byte[], LongRef)
+     * @see NativeProvider#C_WrapKey(long, CKM, long, long, byte[], LongRef)
+     */
+    static void WrapKey(NativeProvider nativeProvider, long session, CKM mechanism, long wrappingKey, long key, byte[] wrappedKey, LongRef wrappedKeyLen) {
+        long rv = NC.WrapKey(nativeProvider, session, mechanism, wrappingKey, key, wrappedKey, wrappedKeyLen);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Wraps (encrypts) a key.
+     * @param session the session's handle
+     * @param mechanism the wrapping mechanism
+     * @param wrappingKey wrapping key
+     * @param key key to be wrapped
+     * @return wrapped key
+     * @see NC#WrapKey(NativeProvider, long, CKM, long, long, byte[], LongRef)
+     * @see NativeProvider#C_WrapKey(long, CKM, long, long, byte[], LongRef)
+     */
+    static byte[] WrapKey(NativeProvider nativeProvider, long session, CKM mechanism, long wrappingKey, long key) {
+        LongRef l = new LongRef();
+        WrapKey(nativeProvider, session, mechanism, wrappingKey, key, null, l);
+        byte[] result = new byte[(int) l.value()];
+        WrapKey(nativeProvider, session, mechanism, wrappingKey, key, result, l);
+        return resize(result, (int) l.value());
+    }
+
+    /**
+     * Unwraps (decrypts) a wrapped key, creating a new key object.
+     * @param session the session's handle
+     * @param mechanism unwrapping mechanism
+     * @param unwrappingKey unwrapping key
+     * @param wrappedKey the wrapped key
+     * @param templ new key template
+     * @param key gets new handle
+     * @see NC#UnwrapKey(NativeProvider, long, CKM, long, byte[], CKA[], LongRef)
+     * @see NativeProvider#C_UnwrapKey(long, CKM, long, byte[], long, CKA[], long, LongRef)
+     */
+    static void UnwrapKey(NativeProvider nativeProvider, long session, CKM mechanism, long unwrappingKey, byte[] wrappedKey, CKA[] templ, LongRef key) {
+        long rv = NC.UnwrapKey(nativeProvider, session, mechanism, unwrappingKey, wrappedKey, templ, key);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Unwraps (decrypts) a wrapped key, creating a new key object.
+     * @param session the session's handle
+     * @param mechanism unwrapping mechanism
+     * @param unwrappingKey unwrapping key
+     * @param wrappedKey the wrapped key
+     * @param templ new key template
+     * @return key handle
+     * @see NC#UnwrapKey(NativeProvider, long, CKM, long, byte[], CKA[], LongRef)
+     * @see NativeProvider#C_UnwrapKey(long, CKM, long, byte[], long, CKA[], long, LongRef)
+     */
+    static long UnwrapKey(NativeProvider nativeProvider, long session, CKM mechanism, long unwrappingKey, byte[] wrappedKey, CKA... templ) {
+        LongRef result = new LongRef();
+        UnwrapKey(nativeProvider, session, mechanism, unwrappingKey, wrappedKey, templ, result);
+        return result.value();
+    }
+
+    /**
+     * Derives a key from a base key, creating a new key object.
+     * @param session the session's handle
+     * @param mechanism key derivation mechanism
+     * @param baseKey base key
+     * @param templ new key template
+     * @param key ges new handle
+     * @see NC#DeriveKey(NativeProvider, long, CKM, long, CKA[], LongRef)
+     * @see NativeProvider#C_DeriveKey(long, CKM, long, CKA[], long, LongRef)
+     */
+    static void DeriveKey(NativeProvider nativeProvider, long session, CKM mechanism, long baseKey, CKA[] templ, LongRef key) {
+        long rv = NC.DeriveKey(nativeProvider, session, mechanism, baseKey, templ, key);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Derives a key from a base key, creating a new key object.
+     * @param session the session's handle
+     * @param mechanism key derivation mechanism
+     * @param baseKey base key
+     * @param templ new key template
+     * @return new handle
+     * @see NC#DeriveKey(NativeProvider, long, CKM, long, CKA[], LongRef)
+     * @see NativeProvider#C_DeriveKey(long, CKM, long, CKA[], long, LongRef)
+     */
+    static long DeriveKey(NativeProvider nativeProvider, long session, CKM mechanism, long baseKey, CKA... templ) {
+        LongRef key = new LongRef();
+        DeriveKey(nativeProvider, session, mechanism, baseKey, templ, key);
+        return key.value();
+    }
+
+    /**
+     * Mixes additional seed material into the token's random number generator.
+     * @param session the session's handle
+     * @param seed the seed material
+     * @see NC#SeedRandom(NativeProvider, long, byte[])
+     * @see NativeProvider#C_SeedRandom(long, byte[], long)
+     */
+    static void SeedRandom(NativeProvider nativeProvider, long session, byte[] seed) {
+        long rv = NC.SeedRandom(nativeProvider, session, seed);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Generates random or pseudo-random data.
+     * @param session the session's handle
+     * @param randomData receives the random data
+     * @see NC#GenerateRandom(NativeProvider, long, byte[])
+     * @see NativeProvider#C_GenerateRandom(long, byte[], long)
+     */
+    static void GenerateRandom(NativeProvider nativeProvider, long session, byte[] randomData) {
+        long rv = NC.GenerateRandom(nativeProvider, session, randomData);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Generates random or pseudo-random data.
+     * @param session the session's handle
+     * @param randomLen number of bytes of random to generate
+     * @return random
+     * @see NC#GenerateRandom(NativeProvider, long, byte[])
+     * @see NativeProvider#C_GenerateRandom(long, byte[], long)
+     */
+    static byte[] GenerateRandom(NativeProvider nativeProvider, long session, int randomLen) {
+        byte[] result = new byte[randomLen];
+        GenerateRandom(nativeProvider, session, result);
+        return result;
+    }
+
+    /**
+     * In previous versions of Cryptoki, C_GetFunctionStatus obtained the status of a function running in parallel
+     * with an application. Now, however, C_GetFunctionStatus is a legacy function which should simply return
+     * the value CKR_FUNCTION_NOT_PARALLEL.
+     * @param session the session's handle
+     * @see NC#GetFunctionStatus(NativeProvider, long)
+     * @see NativeProvider#C_GetFunctionStatus(long)
+     */
+    static void GetFunctionStatus(NativeProvider nativeProvider, long session) {
+        long rv = NC.GetFunctionStatus(nativeProvider, session);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * In previous versions of Cryptoki, C_CancelFunction cancelled a function running in parallel with an application.
+     * Now, however, C_CancelFunction is a legacy function which should simply return the value
+     * CKR_FUNCTION_NOT_PARALLEL.
+     * @param session the session's handle
+     * @see NC#GetFunctionStatus(NativeProvider, long)
+     * @see NativeProvider#C_GetFunctionStatus(long)
+     */
+    static void CancelFunction(NativeProvider nativeProvider, long session) {
+        long rv = NC.CancelFunction(nativeProvider, session);
+        if (rv != CKR.OK) throw new CKRException(rv);
+    }
+
+    /**
+     * Set odd parity on buf and return updated buf.  Buf is modified in-place.
+     * @param buf buf to modify in place and return
+     * @return buf that was passed in
+     */
+    public static byte[] setOddParity(byte[] buf) {
+        for (int i = 0; i < buf.length; i++) {
+            int b = buf[i] & 0xff;
+            b ^= b >> 4;
+            b ^= b >> 2;
+            b ^= b >> 1;
+            buf[i] ^= (b & 1) ^ 1;
+        }
+        return buf;
+    }
+
+    /**
+     * Resize buf to specified length. If buf already size 'newSize', then return buf, else return resized buf.
+     * @param buf buf
+     * @param newSize length to resize to
+     * @return if buf already size 'newSize', then return buf, else return resized buf
+     */
+    public static byte[] resize(byte[] buf, int newSize) {
+        if (buf == null || newSize >= buf.length) {
+            return buf;
+        }
+        byte[] result = new byte[newSize];
+        System.arraycopy(buf, 0, result, 0, result.length);
+        return result;
+    }
+}

--- a/src/main/java/org/pkcs11/jacknji11/jna/JNA.java
+++ b/src/main/java/org/pkcs11/jacknji11/jna/JNA.java
@@ -21,7 +21,6 @@
 
 package org.pkcs11.jacknji11.jna;
 
-import org.pkcs11.jacknji11.C;
 import org.pkcs11.jacknji11.CKA;
 import org.pkcs11.jacknji11.CKM;
 import org.pkcs11.jacknji11.CK_C_INITIALIZE_ARGS;
@@ -32,6 +31,7 @@ import org.pkcs11.jacknji11.CK_SESSION_INFO;
 import org.pkcs11.jacknji11.CK_SLOT_INFO;
 import org.pkcs11.jacknji11.CK_TOKEN_INFO;
 import org.pkcs11.jacknji11.LongRef;
+import org.pkcs11.jacknji11.NC;
 import org.pkcs11.jacknji11.NativePointer;
 import org.pkcs11.jacknji11.NativeProvider;
 import org.pkcs11.jacknji11.ULong;
@@ -54,11 +54,11 @@ public class JNA implements NativeProvider {
     }
 
     private JNANativeI jnaNative = null;
-    
+
     public JNA(){
-        this(C.getLibraryName());
+        this(NC.getLibraryName());
     }
-    
+
     public JNA(String customLibrary) {
         jnaNative = (JNANativeI) com.sun.jna.Native.loadLibrary(customLibrary, JNANativeI.class);
     }
@@ -144,7 +144,7 @@ public class JNA implements NativeProvider {
         Pointer jna_application = new Pointer(application.getAddress());
         final JNA_CK_NOTIFY  jna_notify;
         if (notify == null) {
-            jna_notify = null; 
+            jna_notify = null;
         } else {
             jna_notify = new JNA_CK_NOTIFY() {
                 public NativeLong invoke(NativeLong hSession, NativeLong event, Pointer pApplication) {

--- a/src/test/java/org/pkcs11/jacknji11/InstantiableCryptokiTest.java
+++ b/src/test/java/org/pkcs11/jacknji11/InstantiableCryptokiTest.java
@@ -1,0 +1,714 @@
+/*
+ * Copyright 2010-2011 Joel Hockey (joel.hockey@gmail.com). All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.pkcs11.jacknji11;
+
+import junit.framework.TestCase;
+
+import java.util.Arrays;
+
+/**
+ * JUnit tests for jacknji11.
+ * Tests all the cryptoki functions that I have ever used and understand.
+ * The functions not tested are in commented lines.
+ * @author Joel Hockey (joel.hockey@gmail.com)
+ */
+public class InstantiableCryptokiTest extends TestCase {
+    private byte[] SO_PIN = "sopin".getBytes();
+    private byte[] USER_PIN = "userpin".getBytes();
+    private long TESTSLOT = 0;
+    private long INITSLOT = 1;
+
+    private CEi ce;
+
+    public void setUp() {
+        String testSlotEnv = System.getenv("JACKNJI11_TEST_TESTSLOT");
+        if (testSlotEnv != null && testSlotEnv.length() > 0) {
+            TESTSLOT = Long.parseLong(testSlotEnv);
+        }
+        String initSlotEnv = System.getenv("JACKNJI11_TEST_INITSLOT");
+        if (initSlotEnv != null && initSlotEnv.length() > 0) {
+            INITSLOT = Long.parseLong(initSlotEnv);
+        }
+        String soPinEnv = System.getenv("JACKNJI11_TEST_SO_PIN");
+        if (soPinEnv != null && soPinEnv.length() > 0) {
+            SO_PIN = soPinEnv.getBytes();
+        }
+        String userPinEnv = System.getenv("JACKNJI11_TEST_USER_PIN");
+        if (userPinEnv != null && userPinEnv.length() > 0) {
+            USER_PIN = userPinEnv.getBytes();
+        }
+        // Library path can be set with JACKNJI11_PKCS11_LIB_PATH, or done in code such as:
+        // ce = new CEi(new org.pkcs11.jacknji11.jna.JNA("/usr/lib/softhsm/libsofthsm2.so"));
+        // Or JFFI can be used rather than JNA:
+        // ce = new CEi(new org.pkcs11.jacknji11.jffi.JFFI());
+
+        ce = new CEi();
+        ce.Initialize();
+    }
+
+    public void tearDown() {
+        ce.Finalize();
+    }
+
+    public void testGetInfo() {
+        CK_INFO info = new CK_INFO();
+        ce.GetInfo(info);
+//        System.out.println(info);
+    }
+
+    public void testGetSlotList() {
+        long[] slots = ce.GetSlotList(true);
+//        System.out.println("slots: " + Arrays.toString(slots));
+    }
+
+    public void testGetSlotInfo() {
+        CK_SLOT_INFO info = new CK_SLOT_INFO();
+        ce.GetSlotInfo(TESTSLOT, info);
+//        System.out.println(info);
+    }
+
+    public void testGetTokenInfo() {
+        CK_TOKEN_INFO info = new CK_TOKEN_INFO();
+        ce.GetTokenInfo(TESTSLOT, info);
+//        System.out.println(info);
+    }
+
+    public void testGetMechanismList() {
+        for (long mech : ce.GetMechanismList(TESTSLOT)) {
+//            System.out.println(String.format("0x%08x : %s", mech, CKM.L2S(mech)));
+        }
+    }
+
+    public void testGetMechanismInfo() {
+        CK_MECHANISM_INFO info = new CK_MECHANISM_INFO();
+        ce.GetMechanismInfo(TESTSLOT, CKM.AES_CBC, info);
+//        System.out.println(info);
+    }
+
+    public void testInitTokenInitPinSetPin() {
+        ce.InitToken(INITSLOT, SO_PIN, "TEST".getBytes());
+        long session = ce.OpenSession(INITSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        ce.Login(session, CKU.SO, SO_PIN);
+        ce.InitPIN(session, USER_PIN);
+        ce.Logout(session);
+        ce.Login(session, CKU.USER, USER_PIN);
+        byte[] somenewpin = "somenewpin".getBytes();
+        ce.SetPIN(session, USER_PIN, somenewpin);
+        ce.SetPIN(session, somenewpin, USER_PIN);
+    }
+
+    public void testGetSessionInfo() {
+        long session = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        CK_SESSION_INFO sessionInfo = new CK_SESSION_INFO();
+        ce.GetSessionInfo(session, sessionInfo);
+//        System.out.println(sessionInfo);
+    }
+
+    public void testGetSessionInfoCloseAllSessions() {
+        long s1 = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        long s2 = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        CK_SESSION_INFO info = new CK_SESSION_INFO();
+        ce.GetSessionInfo(s2, info );
+//        System.out.println(info);
+        long s3 = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        ce.CloseSession(s1);
+        ce.CloseAllSessions(TESTSLOT);
+
+        try {
+            ce.CloseSession(s3);
+            fail("Should throw SESSION_HANDLE_INVALID");
+        } catch (CKRException e)
+        {
+            assertEquals(CKR.SESSION_HANDLE_INVALID, e.getCKR());
+        }
+    }
+
+    public void testGetSetOperationState() {
+        long session = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        byte[] state = ce.GetOperationState(session);
+        ce.SetOperationState(session, state, 0, 0);
+    }
+
+    public void testCreateCopyDestroyObject() {
+        long session = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        ce.Login(session, CKU.USER, USER_PIN);
+        CKA[] templ = {
+            new CKA(CKA.CLASS, CKO.DATA),
+            new CKA(CKA.VALUE, "datavalue"),
+        };
+        long o1 = ce.CreateObject(session, templ);
+        CKA[] newTempl = {
+            new CKA(CKA.TOKEN, true),
+        };
+        long o2 = ce.CopyObject(session, o1, newTempl);
+        ce.DestroyObject(session, o1);
+        ce.DestroyObject(session, o2);
+    }
+
+    public void testGetObjectSizeGetSetAtt() {
+        long session = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        ce.Login(session, CKU.USER, USER_PIN);
+        CKA[] templ = {
+            new CKA(CKA.CLASS, CKO.DATA),
+            new CKA(CKA.PRIVATE, false),
+            new CKA(CKA.VALUE, "datavalue"),
+        };
+        long o = ce.CreateObject(session, templ);
+        long size = ce.GetObjectSize(session, o);
+        assertNull(ce.GetAttributeValue(session, o, CKA.LABEL).getValueStr());
+        assertNull(ce.GetAttributeValue(session, o, CKA.ID).getValueStr());
+        assertEquals("datavalue", ce.GetAttributeValue(session, o, CKA.VALUE).getValueStr());
+        assertEquals(Long.valueOf(CKO.DATA), ce.GetAttributeValue(session, o, CKA.CLASS).getValueLong());
+        assertFalse(ce.GetAttributeValue(session, o, CKA.PRIVATE).getValueBool());
+        templ = new CKA[] {
+                // Different HSMs are pick in different ways which attributes can be modified,
+                // just modify label which seems to work on most
+                new CKA(CKA.LABEL, "datalabel"),
+        };
+        ce.SetAttributeValue(session, o, templ);
+        long newsize = ce.GetObjectSize(session, o);
+        if (size > -1) {
+            assertTrue("newsize: " + newsize + ", size " + size, newsize > size);
+        }
+        assertEquals("datalabel", ce.GetAttributeValue(session, o, CKA.LABEL).getValueStr());
+        assertNull(ce.GetAttributeValue(session, o, CKA.ID).getValueStr());
+        assertEquals("datavalue", ce.GetAttributeValue(session, o, CKA.VALUE).getValueStr());
+        assertEquals(Long.valueOf(CKO.DATA), ce.GetAttributeValue(session, o, CKA.CLASS).getValueLong());
+        assertFalse(ce.GetAttributeValue(session, o, CKA.PRIVATE).getValueBool());
+
+        templ = ce.GetAttributeValue(session, o, CKA.LABEL, CKA.ID, CKA.VALUE, CKA.CLASS, CKA.PRIVATE);
+        assertEquals("datalabel", templ[0].getValueStr());
+        assertNull(ce.GetAttributeValue(session, o, CKA.ID).getValueStr());
+        assertEquals("datavalue", templ[2].getValueStr());
+        assertEquals(CKO.DATA, templ[3].getValueLong().longValue());
+        assertFalse(templ[4].getValueBool());
+
+        templ = ce.GetAttributeValue(session, o, CKA.LABEL, CKA.ID, CKA.OBJECT_ID, CKA.TRUSTED);
+        assertEquals("datalabel", templ[0].getValueStr());
+        assertNull(ce.GetAttributeValue(session, o, CKA.ID).getValueStr());
+        assertNull(templ[2].getValue());
+        assertNull(templ[3].getValueBool());
+    }
+
+    public void testFindObjects() {
+        long session = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        ce.Login(session, CKU.USER, USER_PIN); // Needed depending on HSM policy
+        // create a few objects
+        CKA[] templ = {
+            new CKA(CKA.CLASS, CKO.DATA),
+            new CKA(CKA.LABEL, "label1"),
+        };
+        long o1 = ce.CreateObject(session, templ);
+        long o2 = ce.CreateObject(session, templ);
+        long o3 = ce.CreateObject(session, templ);
+        assertTrue(o1 != o2);
+        templ[1] = new CKA(CKA.LABEL, "label2");
+        long o4 = ce.CreateObject(session, templ);
+
+        templ = new CKA[] {new CKA(CKA.LABEL, "label1")};
+        ce.FindObjectsInit(session, templ);
+        assertEquals(2, ce.FindObjects(session, 2).length);
+        assertEquals(1, ce.FindObjects(session, 2).length);
+        assertEquals(0, ce.FindObjects(session, 2).length);
+        ce.FindObjectsFinal(session);
+        templ = new CKA[] {new CKA(CKA.LABEL, "label2")};
+        ce.FindObjectsInit(session, templ);
+        long[] found = ce.FindObjects(session, 2);
+        assertEquals(1, found.length);
+        assertEquals(o4, found[0]);
+        assertEquals(0, ce.FindObjects(session, 2).length);
+        ce.FindObjectsFinal(session);
+    }
+
+
+    public void testEncryptDecrypt() {
+        long session = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        ce.LoginUser(session, USER_PIN);
+
+        long aeskey = ce.GenerateKey(session, new CKM(CKM.AES_KEY_GEN),
+                new CKA(CKA.VALUE_LEN, 32),
+                new CKA(CKA.LABEL, "labelencaes"),
+                new CKA(CKA.ID, "labelencaes"),
+                new CKA(CKA.TOKEN, false),
+                new CKA(CKA.SENSITIVE, false),
+                new CKA(CKA.ENCRYPT, true),
+                new CKA(CKA.DECRYPT, true),
+                new CKA(CKA.DERIVE, true));
+
+        ce.EncryptInit(session, new CKM(CKM.AES_CBC_PAD), aeskey);
+        byte[] plaintext = new byte[10];
+        byte[] encrypted1 = ce.EncryptPad(session, plaintext);
+        ce.EncryptInit(session, new CKM(CKM.AES_CBC_PAD), aeskey);
+        byte[] encrypted2a = ce.EncryptUpdate(session, new byte[6]);
+        byte[] encrypted2b = ce.EncryptUpdate(session, new byte[4]);
+        byte[] encrypted2c = ce.EncryptFinal(session);
+        assertTrue(Arrays.equals(encrypted1, Buf.cat(encrypted2a, encrypted2b, encrypted2c)));
+
+        ce.DecryptInit(session, new CKM(CKM.AES_CBC_PAD), aeskey);
+        byte[] decrypted1 = ce.DecryptPad(session, encrypted1);
+        assertTrue(Arrays.equals(plaintext, decrypted1));
+        ce.DecryptInit(session, new CKM(CKM.AES_CBC_PAD), aeskey);
+        byte[] decrypted2a = ce.DecryptUpdate(session, Buf.substring(encrypted1, 0, 8));
+        byte[] decrypted2b = ce.DecryptUpdate(session, Buf.substring(encrypted1, 8, 8));
+        byte[] decrypted2c = ce.DecryptFinal(session);
+        assertTrue(Arrays.equals(plaintext, Buf.cat(decrypted2a, decrypted2b, decrypted2c)));
+    }
+
+    public void testDigest() {
+        long session = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        ce.Login(session, CKU.USER, USER_PIN); // Needed depending on HSM policy
+        ce.DigestInit(session, new CKM(CKM.SHA256));
+        byte[] digested1 = ce.Digest(session, new byte[100]);
+        assertEquals(32, digested1.length);
+        ce.DigestInit(session, new CKM(CKM.SHA256));
+        ce.DigestUpdate(session, new byte[50]);
+        ce.DigestUpdate(session, new byte[50]);
+        byte[] digested2 = ce.DigestFinal(session);
+        assertTrue(Arrays.equals(digested1, digested2));
+
+        long aeskey = ce.GenerateKey(session, new CKM(CKM.AES_KEY_GEN),
+                new CKA(CKA.VALUE_LEN, 24),
+                new CKA(CKA.LABEL, "labelaesdigest"),
+                new CKA(CKA.ID, "labelaesdigest"),
+                new CKA(CKA.TOKEN, false),
+                new CKA(CKA.SENSITIVE, false),
+                new CKA(CKA.DERIVE, true));
+
+        ce.DigestInit(session, new CKM(CKM.SHA256));
+        ce.DigestKey(session, aeskey);
+        byte[] digestedKey = ce.DigestFinal(session);
+    }
+
+    public void testSignVerifyRSAPKCS1() {
+        long session = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        ce.LoginUser(session, USER_PIN);
+        // Different HSMs have a little different requirements on templates, regardless of which are mandatory or not
+        // in the P11 spec. To work with as many HSMs as possible, use a good default, as complete as possible, template.
+        // On most HSMs you can set CKA_ID after key generations, but some requires adding CKA_ID at generation time
+        CKA[] pubTempl = new CKA[] {
+            new CKA(CKA.MODULUS_BITS, 1024),
+            new CKA(CKA.PUBLIC_EXPONENT, Hex.s2b("010001")),
+            new CKA(CKA.WRAP, false),
+            new CKA(CKA.ENCRYPT, false),
+            new CKA(CKA.VERIFY, true),
+            new CKA(CKA.TOKEN, true),
+            new CKA(CKA.LABEL, "labelrsa-public"),
+            new CKA(CKA.ID, "labelrsa"),
+        };
+        CKA[] privTempl = new CKA[] {
+            new CKA(CKA.TOKEN, true),
+            new CKA(CKA.PRIVATE, true),
+            new CKA(CKA.SENSITIVE, true),
+            new CKA(CKA.SIGN, true),
+            new CKA(CKA.DECRYPT, false),
+            new CKA(CKA.UNWRAP, false),
+            new CKA(CKA.EXTRACTABLE, false),
+            new CKA(CKA.LABEL, "labelrsa-private"),
+            new CKA(CKA.ID, "labelrsa"),
+        };
+        LongRef pubKey = new LongRef();
+        LongRef privKey = new LongRef();
+        ce.GenerateKeyPair(session, new CKM(CKM.RSA_PKCS_KEY_PAIR_GEN), pubTempl, privTempl, pubKey, privKey);
+
+        // Direct sign
+        byte[] data = new byte[100];
+        ce.SignInit(session, new CKM(CKM.SHA256_RSA_PKCS), privKey.value());
+        byte[] sig1 = ce.Sign(session, data);
+        assertEquals(128, sig1.length);
+
+        ce.VerifyInit(session, new CKM(CKM.SHA256_RSA_PKCS), pubKey.value());
+        ce.Verify(session, data, sig1);
+
+        // Using SignUpdate
+        ce.SignInit(session, new CKM(CKM.SHA256_RSA_PKCS), privKey.value());
+        ce.SignUpdate(session, new byte[50]);
+        ce.SignUpdate(session, new byte[50]);
+        byte[] sig2 = ce.SignFinal(session);
+        assertTrue(Arrays.equals(sig1, sig2));
+
+        ce.VerifyInit(session, new CKM(CKM.SHA256_RSA_PKCS), pubKey.value());
+        ce.VerifyUpdate(session, new byte[50]);
+        ce.VerifyUpdate(session, new byte[50]);
+        ce.VerifyFinal(session, sig2);
+
+        ce.VerifyInit(session, new CKM(CKM.SHA256_RSA_PKCS), pubKey.value());
+        try {
+            ce.Verify(session, data, new byte[128]);
+            fail("CE Verify with no real signature should throw exception");
+        } catch (CKRException e) {
+            assertEquals("Failure with invalid signature data should be CKR.SIGNATURE_INVALID", CKR.SIGNATURE_INVALID, e.getCKR());
+        }
+    }
+
+    public void testSignVerifyRSAPSS() {
+        long session = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        ce.LoginUser(session, USER_PIN);
+        CKA[] pubTempl = new CKA[] {
+            new CKA(CKA.MODULUS_BITS, 1024),
+            new CKA(CKA.PUBLIC_EXPONENT, Hex.s2b("010001")),
+            new CKA(CKA.WRAP, false),
+            new CKA(CKA.ENCRYPT, false),
+            new CKA(CKA.VERIFY, true),
+            new CKA(CKA.TOKEN, true),
+            new CKA(CKA.LABEL, "label-public"),
+            new CKA(CKA.ID, "label"),
+        };
+        CKA[] privTempl = new CKA[] {
+            new CKA(CKA.TOKEN, true),
+            new CKA(CKA.PRIVATE, true),
+            new CKA(CKA.SENSITIVE, true),
+            new CKA(CKA.SIGN, true),
+            new CKA(CKA.DECRYPT, false),
+            new CKA(CKA.UNWRAP, false),
+            new CKA(CKA.EXTRACTABLE, false),
+            new CKA(CKA.LABEL, "label-private"),
+            new CKA(CKA.ID, "label"),
+        };
+        LongRef pubKey = new LongRef();
+        LongRef privKey = new LongRef();
+        ce.GenerateKeyPair(session, new CKM(CKM.RSA_PKCS_KEY_PAIR_GEN), pubTempl, privTempl, pubKey, privKey);
+
+        // RSA-PSS needs parameters, which specifies the padding to be used, matching the hash algorithm
+        byte[] params = ULong.ulong2b(new long[]{CKM.SHA256, CKG.MGF1_SHA256, 32});
+        CKM ckm = new CKM(CKM.SHA256_RSA_PKCS_PSS, params);
+
+        // Direct sign
+        byte[] data = new byte[100];
+        ce.SignInit(session, ckm, privKey.value());
+        byte[] sig1 = ce.Sign(session, data);
+        assertEquals(128, sig1.length);
+
+        ce.VerifyInit(session, ckm, pubKey.value());
+        ce.Verify(session, data, sig1);
+
+        // Using SignUpdate
+        ce.SignInit(session, ckm, privKey.value());
+        ce.SignUpdate(session, new byte[50]);
+        ce.SignUpdate(session, new byte[50]);
+        byte[] sig2 = ce.SignFinal(session);
+        // RSA-PSS uses randomness, so two signatures can not be compared as with RSA PKCS#1
+        //assertTrue(Arrays.equals(sig1, sig2));
+
+        ce.VerifyInit(session, ckm, pubKey.value());
+        ce.VerifyUpdate(session, new byte[50]);
+        ce.VerifyUpdate(session, new byte[50]);
+        ce.VerifyFinal(session, sig2);
+
+        ce.VerifyInit(session, ckm, pubKey.value());
+        try {
+            ce.Verify(session, data, new byte[128]);
+            fail("CE Verify with no real signature should throw exception");
+        } catch (CKRException e) {
+            assertEquals("Failure with invalid signature data should be CKR.SIGNATURE_INVALID", CKR.SIGNATURE_INVALID, e.getCKR());
+        }
+    }
+
+    public void testSignVerifyECDSA() {
+        long session = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        ce.LoginUser(session, USER_PIN);
+        // Attributes from PKCS #11 Cryptographic Token Interface Current Mechanisms Specification
+        //   Version 2.40 section 2.3.3 - ECDSA public key objects
+        // We use a P-256 key (also known as secp256r1 or prime256v1), the oid 1.2.840.10045.3.1.7
+        //   has DER encoding in Hex 06082a8648ce3d030107
+        // DER-encoding of an ANSI X9.62 Parameters, also known as "EC domain parameters".
+        //   See X9.62-1998 Public Key Cryptography For The Financial Services Industry:
+        //   The Elliptic Curve Digital Signature Algorithm (ECDSA), page 27.
+        byte[] ecCurveParams = Hex.s2b("06082a8648ce3d030107");
+        CKA[] pubTempl = new CKA[] {
+            new CKA(CKA.EC_PARAMS, ecCurveParams),
+            new CKA(CKA.WRAP, false),
+            new CKA(CKA.ENCRYPT, false),
+            new CKA(CKA.VERIFY, true),
+            new CKA(CKA.VERIFY_RECOVER, false),
+            new CKA(CKA.TOKEN, true),
+            new CKA(CKA.LABEL, "labelec-public"),
+            new CKA(CKA.ID, "labelec"),
+        };
+        CKA[] privTempl = new CKA[] {
+            new CKA(CKA.TOKEN, true),
+            new CKA(CKA.PRIVATE, true),
+            new CKA(CKA.SENSITIVE, true),
+            new CKA(CKA.SIGN, true),
+            new CKA(CKA.SIGN_RECOVER, false),
+            new CKA(CKA.DECRYPT, false),
+            new CKA(CKA.UNWRAP, false),
+            new CKA(CKA.EXTRACTABLE, false),
+            new CKA(CKA.LABEL, "labelec-private"),
+            new CKA(CKA.ID, "labelec"),
+        };
+        LongRef pubKey = new LongRef();
+        LongRef privKey = new LongRef();
+        ce.GenerateKeyPair(session, new CKM(CKM.ECDSA_KEY_PAIR_GEN), pubTempl, privTempl, pubKey, privKey);
+
+        // Direct sign, PKCS#11 "2.3.6 ECDSA without hashing"
+        byte[] data = new byte[32]; // SHA256 hash is 32 bytes
+        ce.SignInit(session, new CKM(CKM.ECDSA), privKey.value());
+        byte[] sig1 = ce.Sign(session, data);
+        assertEquals(64, sig1.length);
+
+        ce.VerifyInit(session, new CKM(CKM.ECDSA), pubKey.value());
+        ce.Verify(session, data, sig1);
+
+        ce.VerifyInit(session, new CKM(CKM.ECDSA), pubKey.value());
+        try {
+            ce.Verify(session, data, new byte[64]);
+            fail("CE Verify with no real signature should throw exception");
+        } catch (CKRException e) {
+            assertEquals("Failure with invalid signature data should be CKR.SIGNATURE_INVALID", CKR.SIGNATURE_INVALID, e.getCKR());
+        }
+    }
+
+    /** https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.0/os/pkcs11-curr-v3.0-os.html#_Toc30061191
+     */
+    public void testSignVerifyEdDSA() {
+        long session = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        ce.LoginUser(session, USER_PIN);
+        // CKM_EC_EDWARDS_KEY_PAIR_GEN
+        /*
+            The mechanism can only generate EC public/private key pairs over the curves edwards25519 and edwards448 as defined in RFC 8032 or the curves
+            id-Ed25519 and id-Ed448 as defined in RFC 8410. These curves can only be specified in the CKA_EC_PARAMS attribute of the template for the
+            public key using the curveName or the oID methods
+        */
+        // CKM_EDDSA (signature mechanism)
+        /*
+            CK_EDDSA_PARAMS is a structure that provides the parameters for the CKM_EDDSA signature mechanism.  The structure is defined as follows:
+            typedef struct CK_EDDSA_PARAMS {
+                CK_BBOOL     phFlag;
+                CK_ULONG     ulContextDataLen;
+                CK_BYTE_PTR  pContextData;
+            }  CK_EDDSA_PARAMS
+        */
+        // CK_EDDSA_PARAMS (no params means Ed25519 in keygen?)
+        // CK_EDDSA_PARAMS_PTR is a pointer to a CK_EDDSA_PARAMS
+        // CKK_EC_EDWARDS (private and public key)
+
+        // Attributes from PKCS #11 Cryptographic Token Interface Current Mechanisms Specification Version 2.40 section 2.3.3 - ECDSA public key objects
+        /* DER-encoding of an ANSI X9.62 Parameters, also known as "EC domain parameters". */
+        // We use a Ed25519 key, the oid 1.3.101.112 has DER encoding in Hex 06032b6570
+        byte[] ecCurveParams = Hex.s2b("06032b6570");
+        CKA[] pubTempl = new CKA[] {
+            new CKA(CKA.EC_PARAMS, ecCurveParams),
+            new CKA(CKA.WRAP, false),
+            new CKA(CKA.ENCRYPT, false),
+            new CKA(CKA.VERIFY, true),
+            new CKA(CKA.VERIFY_RECOVER, false),
+            new CKA(CKA.TOKEN, true),
+            new CKA(CKA.LABEL, "label-public"),
+            new CKA(CKA.ID, "label"),
+        };
+        CKA[] privTempl = new CKA[] {
+            new CKA(CKA.TOKEN, true),
+            new CKA(CKA.PRIVATE, true),
+            new CKA(CKA.SENSITIVE, true),
+            new CKA(CKA.SIGN, true),
+            new CKA(CKA.SIGN_RECOVER, false),
+            new CKA(CKA.DECRYPT, false),
+            new CKA(CKA.UNWRAP, false),
+            new CKA(CKA.EXTRACTABLE, false),
+            new CKA(CKA.LABEL, "label-private"),
+            new CKA(CKA.ID, "label"),
+        };
+        LongRef pubKey = new LongRef();
+        LongRef privKey = new LongRef();
+        ce.GenerateKeyPair(session, new CKM(CKM.EC_EDWARDS_KEY_PAIR_GEN), pubTempl, privTempl, pubKey, privKey);
+
+        // Direct sign, PKCS#11 "2.3.14 EdDSA"
+        byte[] data = new byte[32]; // SHA256 hash is 32 bytes
+        ce.SignInit(session, new CKM(CKM.EDDSA), privKey.value());
+        byte[] sig1 = ce.Sign(session, data);
+        assertEquals(64, sig1.length);
+
+        ce.VerifyInit(session, new CKM(CKM.EDDSA), pubKey.value());
+        ce.Verify(session, data, sig1);
+
+        ce.VerifyInit(session, new CKM(CKM.EDDSA), pubKey.value());
+        try {
+            ce.Verify(session, data, new byte[64]);
+            fail("CE Verify with no real signature should throw exception");
+        } catch (CKRException e) {
+            assertEquals("Failure with invalid signature data should be CKR.SIGNATURE_INVALID", CKR.SIGNATURE_INVALID, e.getCKR());
+        }
+    }
+
+    /** SignRecoverInit and VerifyRecoverInit is not supported on all HSMs,
+     * so it has a separate test that may expect to fail with FUNCTION_NOT_SUPPORTED
+     */
+    public void testSignVerifyRecoveryRSA() {
+        long session = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        ce.LoginUser(session, USER_PIN);
+        // See comments on the method testSignVerifyRSA
+        CKA[] pubTempl = new CKA[] {
+            new CKA(CKA.MODULUS_BITS, 1024),
+            new CKA(CKA.PUBLIC_EXPONENT, Hex.s2b("010001")),
+            new CKA(CKA.WRAP, false),
+            new CKA(CKA.ENCRYPT, false),
+            new CKA(CKA.VERIFY, true),
+            new CKA(CKA.VERIFY_RECOVER, true),
+            new CKA(CKA.TOKEN, true),
+            new CKA(CKA.LABEL, "labelrsa2-public"),
+            new CKA(CKA.ID, "labelrsa2"),
+        };
+        CKA[] privTempl = new CKA[] {
+            new CKA(CKA.TOKEN, true),
+            new CKA(CKA.PRIVATE, true),
+            new CKA(CKA.SENSITIVE, true),
+            new CKA(CKA.SIGN, true),
+            new CKA(CKA.SIGN_RECOVER, true),
+            new CKA(CKA.DECRYPT, false),
+            new CKA(CKA.UNWRAP, false),
+            new CKA(CKA.EXTRACTABLE, false),
+            new CKA(CKA.LABEL, "labelrsa2-private"),
+            new CKA(CKA.ID, "labelrsa2"),
+        };
+        LongRef pubKey = new LongRef();
+        LongRef privKey = new LongRef();
+        ce.GenerateKeyPair(session, new CKM(CKM.RSA_PKCS_KEY_PAIR_GEN), pubTempl, privTempl, pubKey, privKey);
+
+        byte[] data = new byte[100];
+        ce.SignInit(session, new CKM(CKM.SHA256_RSA_PKCS), privKey.value());
+        byte[] sig1 = ce.Sign(session, data);
+        assertEquals(128, sig1.length);
+
+        data = new byte[10];
+        ce.SignRecoverInit(session, new CKM(CKM.RSA_PKCS), privKey.value());
+        byte[] sigrec1 = ce.SignRecover(session, data);
+        assertEquals(64, sig1.length);
+        ce.VerifyRecoverInit(session, new CKM(CKM.RSA_PKCS), pubKey.value());
+        byte[] recdata = ce.VerifyRecover(session, sigrec1);
+        assertTrue(Arrays.equals(data, recdata));
+    }
+
+//    public static native long C_DigestEncryptUpdate(long session, byte[] part, long part_len, byte[] encrypted_part, LongRef encrypted_part_len);
+//    public static native long C_DecryptDigestUpdate(long session, byte[] encrypted_part, long encrypted_part_len, byte[] part, LongRef part_len);
+//    public static native long C_SignEncryptUpdate(long session, byte[] part, long part_len, byte[] encrypted_part, LongRef encrypted_part_len);
+//    public static native long C_DecryptVerifyUpdate(long session, byte[] encrypted_part, long encrypted_part_len, byte[] part, LongRef part_len);
+
+
+    public void testGenerateKeyWrapUnwrap() {
+        long session = ce.OpenSession(TESTSLOT);
+        ce.LoginUser(session, USER_PIN);
+
+//        CKA[] secTempl = new CKA[] {
+//                new CKA(CKA.VALUE_LEN, 32),
+//                new CKA(CKA.LABEL, "labelwrap"),
+//                new CKA(CKA.ID, "labelwrap"),
+//                new CKA(CKA.TOKEN, false),
+//                new CKA(CKA.SENSITIVE, false),
+//                new CKA(CKA.EXTRACTABLE, true),
+//                new CKA(CKA.ENCRYPT, true),
+//                new CKA(CKA.DECRYPT, true),
+//                new CKA(CKA.DERIVE, true),
+//        };
+//        long aeskey = ce.GenerateKey(session, new CKM(CKM.AES_KEY_GEN), secTempl);
+        long aeskey = ce.GenerateKey(session, new CKM(CKM.AES_KEY_GEN),
+                new CKA(CKA.VALUE_LEN, 32),
+                new CKA(CKA.LABEL, "labelwrap"),
+                new CKA(CKA.ID, "labelwrap"),
+                new CKA(CKA.TOKEN, false),
+                new CKA(CKA.SENSITIVE, false),
+                new CKA(CKA.EXTRACTABLE, true),
+                new CKA(CKA.DERIVE, true));
+        byte[] aeskeybuf = ce.GetAttributeValue(session, aeskey, CKA.VALUE).getValue();
+
+        // See comments on the method testSignVerifyRSA
+        CKA[] pubTempl = new CKA[] {
+            new CKA(CKA.MODULUS_BITS, 1024),
+            new CKA(CKA.PUBLIC_EXPONENT, Hex.s2b("010001")),
+            new CKA(CKA.WRAP, true),
+            new CKA(CKA.ENCRYPT, false),
+            new CKA(CKA.VERIFY, true),
+            new CKA(CKA.VERIFY_RECOVER, true),
+            new CKA(CKA.TOKEN, true),
+            new CKA(CKA.LABEL, "labelrsa3-public"),
+            new CKA(CKA.ID, "labelrsa3"),
+        };
+        CKA[] privTempl = new CKA[] {
+            new CKA(CKA.TOKEN, true),
+            new CKA(CKA.PRIVATE, true),
+            new CKA(CKA.SENSITIVE, true),
+            new CKA(CKA.SIGN, true),
+            new CKA(CKA.SIGN_RECOVER, true),
+            new CKA(CKA.DECRYPT, false),
+            new CKA(CKA.UNWRAP, true),
+            new CKA(CKA.EXTRACTABLE, false),
+            new CKA(CKA.LABEL, "labelrsa3-private"),
+            new CKA(CKA.ID, "labelrsa3"),
+        };
+        LongRef pubKey = new LongRef();
+        LongRef privKey = new LongRef();
+        ce.GenerateKeyPair(session, new CKM(CKM.RSA_PKCS_KEY_PAIR_GEN), pubTempl, privTempl, pubKey, privKey);
+
+        // Key wrapping, i.e. exporting a key from the HSM. Wrapping with RSA means you wrap (encrypt) the key
+        // with the RSA public key and you unwrap (decrypt) it with the RSA private key
+        // http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/csprd02/pkcs11-curr-v2.40-csprd02.html#_Toc387327730
+        byte[] wrapped = ce.WrapKey(session, new CKM(CKM.RSA_PKCS), pubKey.value(), aeskey);
+
+        // We need to provide a full set of attributes for the secret key in order to unwrap it inside the HSM
+        // Unwrapping is done with the RSA private key, i.e. the secret key is never exposed unencrypted outside
+        // of the HSM (if we had generated the secret key with CKA.EXTRACTABLE=false that is)
+        CKA[] secTemplUnwrap = new CKA[] {
+                new CKA(CKA.CLASS, CKO.SECRET_KEY),
+                new CKA(CKA.KEY_TYPE, CKK.AES),
+                new CKA(CKA.LABEL, "labelunwrap"),
+                new CKA(CKA.ID, "labelunwrap"),
+                new CKA(CKA.TOKEN, false),
+                new CKA(CKA.SENSITIVE, false),
+                new CKA(CKA.EXTRACTABLE, true),
+                new CKA(CKA.ENCRYPT, true),
+                new CKA(CKA.DECRYPT, true),
+                new CKA(CKA.DERIVE, true),
+        };
+        long aeskey2 = ce.UnwrapKey(session, new CKM(CKM.RSA_PKCS), privKey.value(), wrapped, secTemplUnwrap);
+        byte[] aeskey2buf = ce.GetAttributeValue(session, aeskey2, CKA.VALUE).getValue();
+        assertTrue(Arrays.equals(aeskey2buf, aeskeybuf));
+
+    }
+
+    public void testPTKDES3Derive() {
+        long session = ce.OpenSession(TESTSLOT);
+        ce.LoginUser(session, USER_PIN);
+
+        long des3key = ce.GenerateKey(session, new CKM(CKM.DES3_KEY_GEN),
+                new CKA(CKA.VALUE_LEN, 24),
+                new CKA(CKA.LABEL, "label"),
+                new CKA(CKA.SENSITIVE, false),
+                new CKA(CKA.DERIVE, true));
+        byte[] des3keybuf = ce.GetAttributeValue(session, des3key, CKA.VALUE).getValue();
+
+      ce.DeriveKey(session, new CKM(CKM.VENDOR_PTK_DES3_DERIVE_CBC, new byte[32]), des3key);
+    }
+
+    public void testRandom() {
+        long session = ce.OpenSession(TESTSLOT, CK_SESSION_INFO.CKF_RW_SESSION | CK_SESSION_INFO.CKF_SERIAL_SESSION, null, null);
+        byte[] buf = new byte[16];
+        ce.SeedRandom(session, buf);
+        ce.GenerateRandom(session, buf);
+        byte[] buf2 = ce.GenerateRandom(session, 16);
+    }
+
+//    public static native long C_GetFunctionStatus(long session);
+//    public static native long C_CancelFunction(long session);
+
+
+//    public static native long C_WaitForSlotEvent(long flags, LongRef slot, Pointer pReserved);
+//    public static native long C_SetOperationState(long session, byte[] operation_state, long operation_state_len, long encryption_key, long authentication_key);
+}


### PR DESCRIPTION
As discussed in #44 - an alternative implementation of the proposed `Ci` and `CEi` classes that attempts to keeps backwards compatibility by delegating the business logic to the `NC` and `NCE` classes:

1. Add new static methods that accept a NativeProvider instance (instead of relying on the public field).
2. Have the original static methods delegate to the new static methods (and deprecate them).
3. Add the new Ci class and have it also delegate to the new static methods.

The PR is not complete yet - notably not all Javadocs have been properly updated - but can be used as a starting point for discussion. 