### PR TITLE
Make the CryptokiE constructors public.

### DIFF
--- a/src/main/java/org/pkcs11/jacknji11/Cryptoki.java
+++ b/src/main/java/org/pkcs11/jacknji11/Cryptoki.java
@@ -71,7 +71,7 @@ public class Cryptoki {
 
     private static final NativePointer NULL = new NativePointer(0);
 
-    private NativeProvider provider;
+    private final NativeProvider provider;
 
     /**
      * Default constructor uses {@link org.pkcs11.jacknji11.jna.JNA}
@@ -142,7 +142,7 @@ public class Cryptoki {
      * @param slotList receives array of slot IDs
      * @param count receives the number of slots
      * @return {@link CKR} return code
-     * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef) 
+     * @see NativeProvider#C_GetSlotList(boolean, long[], LongRef)
      */
     public long GetSlotList(boolean tokenPresent, long[] slotList, LongRef count) {
         if (log.isDebugEnabled()) log.debug(String.format("> C_GetSlotList tokenPresent=%b count=%d", tokenPresent, count.value()));

--- a/src/main/java/org/pkcs11/jacknji11/CryptokiE.java
+++ b/src/main/java/org/pkcs11/jacknji11/CryptokiE.java
@@ -57,16 +57,16 @@ package org.pkcs11.jacknji11;
  */
 public class CryptokiE {
 
-    private Cryptoki c;
+    private final Cryptoki c;
 
-    CryptokiE() {
+    public CryptokiE() {
       this.c = new Cryptoki();
     }
 
     /**
      * @param c Cryptoki object to wrap.
      */
-    CryptokiE(Cryptoki c) {
+    public CryptokiE(Cryptoki c) {
       this.c = c;
     }
 


### PR DESCRIPTION
Since the `CryptokiE` class is intended to be used as the recommended API going forward I've made the constructors public. 
I've also set the private `Cryptoki c`/NativeProvider fields to `final` to improve maintainability. 