### PR TITLE
Add constructor in JNA for providing the JNA Native instance.

### DIFF
--- a/src/main/java/org/pkcs11/jacknji11/jna/JNA.java
+++ b/src/main/java/org/pkcs11/jacknji11/jna/JNA.java
@@ -63,6 +63,10 @@ public class JNA implements NativeProvider {
         jnaNative = (JNANativeI) com.sun.jna.Native.loadLibrary(customLibrary, JNANativeI.class);
     }
 
+    public JNA(JNANativeI jnaNative) {
+        this.jnaNative = jnaNative;
+    }
+
     public long C_Initialize(CK_C_INITIALIZE_ARGS pInitArgs) {
         if(pInitArgs.createMutex == null && pInitArgs.destroyMutex == null && pInitArgs.lockMutex == null && pInitArgs.unlockMutex == null)
             return jnaNative.C_Initialize(null);


### PR DESCRIPTION
This Pull Request adds a constructor to the JNA class allowing the caller to provide the JNA Native instance object.

This change allows the possibility to control the creation of the JNANativeI. One reason one would like to do that is for the case when one is using a cryptoki library that in addition to the standard functions also has some vendor-specific, custom or not-yet standard functions that one would like to use. With this change it could then be possible to create an extended JNANativeI class that also has this other functions before those becomes available in JackNJI11.

We have been using the library like this since long time and it works well. First we did it because we needed to provide a customLibrary name however now that is available in the constructor but we still need to do it like this in order to work with the non-standard functions.

This is the last critical change we have in our branch so hopefully after this we will be able to use the official code.