### PR TITLE
Pass on provided initialization args even if all mutexes are null.

### DIFF
--- a/src/main/java/org/pkcs11/jacknji11/jna/JNA.java
+++ b/src/main/java/org/pkcs11/jacknji11/jna/JNA.java
@@ -68,8 +68,6 @@ public class JNA implements NativeProvider {
     }
 
     public long C_Initialize(CK_C_INITIALIZE_ARGS pInitArgs) {
-        if(pInitArgs.createMutex == null && pInitArgs.destroyMutex == null && pInitArgs.lockMutex == null && pInitArgs.unlockMutex == null)
-            return jnaNative.C_Initialize(null);
         return jnaNative.C_Initialize(new JNA_CK_C_INITIALIZE_ARGS(pInitArgs));
     }
 


### PR DESCRIPTION
The null check is not needed here as since #5 the JNA_CK_C_INITIALIZE_ARGS handles those.
And the big issue with the old code is that if the args are not passed on any provided flag within it is also not. This could cause Java process crashes as CKF_OS_LOCKING_OK is missing.