### PR TITLE
FindObjects in fixed-size batches of 1024, instead of increasing

### DIFF
--- a/src/main/java/org/pkcs11/jacknji11/CryptokiE.java
+++ b/src/main/java/org/pkcs11/jacknji11/CryptokiE.java
@@ -792,15 +792,14 @@ public class CryptokiE {
                 return result;
             }
 
-            // this is a lot of objects!
+            // this is a lot of objects! try to find in batches of 1024 more, adding to result as we go
             while (true) {
-                maxObjects *= 2;
                 long[] found = FindObjects(session, maxObjects);
                 long[] temp = new long[result.length + found.length];
                 System.arraycopy(result, 0, temp, 0, result.length);
                 System.arraycopy(found, 0, temp, result.length, found.length);
                 result = temp;
-                if (found.length < maxObjects) { // exhausted
+                if (found.length < maxObjects) { // exhausted, didn't find 1024 more
                     success = true;
                     return result;
                 }


### PR DESCRIPTION
This commit from @primetomas changes the batch size in FindObjects to a fixed value of 1024, instead of exponentially increasing buffer size.

This fixes a bug with AWS CloudHSM, which returns ARGUMENTS_BAD if the buffer size increases in continued FindObject calls.