### PR TITLE
Improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,20 @@
           <target>1.8</target>
         </configuration>
       </plugin>
+      <!-- add source jar -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/org/pkcs11/jacknji11/AttributeLengthStrategy.java
+++ b/src/main/java/org/pkcs11/jacknji11/AttributeLengthStrategy.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2010-2011 Joel Hockey (joel.hockey@gmail.com). All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.pkcs11.jacknji11;
+
+/**
+ * Strategy for determining length of attribute value in C_GetAttributeValue request.
+ *
+ * @author Tomasz Wysocki
+ */
+public interface AttributeLengthStrategy {
+
+    /**
+     * Get expected length of attribute value in C_GetAttributeValue request.
+     *
+     * @param cka attribute type
+     * @return expected length of attribute value or 0 if length should be queried.
+     */
+    int getAttributeLength(long cka);
+
+    /**
+     * Implementation of {@link AttributeLengthStrategy} that is using a list of large attributes
+     * and their maximum length as well as a default length for regular attributes.
+     * <p>
+     * Use to avoid querying length of attributes for every call to C_GetAttributeValue.
+     */
+    class MaxLengthStrategy implements AttributeLengthStrategy {
+
+        /**
+         * Default of 2KB has been established by following facts:
+         * Modulus of 15Kb RSA (maximum) is around 2KB.
+         * For 7168Kb RSA (which is a practical limit) certificates are about 2K (without extensions).
+         * <p>
+         * Note: CKA_VALUE is used also for certificate objects, so it is large value as well - which is shame
+         * since value is typically used for symmetric keys which are relatively small size.
+         * <p>
+         * If set to 0 then max length strategy is not used for large attributes.
+         */
+        public static final int DEFAULT_LARGE_ATTRIBUTE_LENGTH = 2048;
+
+        /**
+         * Default 72 (divisible by 8) bytes should be sufficient for most attributes including custom labels and ids
+         * as well as EC P-521 compressed public key ( 1B tag | 66B x )
+         */
+        public static final int DEFAULT_REGULAR_ATTRIBUTE_LENGTH = 72;
+
+        /**
+         * Set of large attributes types established to potentially contain large values.
+         */
+        public static final long[] DEFAULT_LARGE_ATTRIBUTES = new long[]{
+                CKA.MODULUS,
+                CKA.PRIME_1,
+                CKA.PRIME_2,
+                CKA.EXPONENT_1,
+                CKA.EXPONENT_2,
+                CKA.COEFFICIENT,
+                CKA.PRIVATE_EXPONENT,
+                CKA.VALUE,
+                CKA.EC_POINT,
+        };
+
+        /**
+         * Large attribute types.
+         */
+        private final long[] largeAttributes;
+
+        /**
+         * Length for large attributes, if 0 then max length strategy is not used for large attributes.
+         */
+        private final int largeAttributeLength;
+
+        /**
+         * Default length for attributes, if 0 then max length strategy is not used for regular attributes.
+         */
+        private final int regularAttributeLength;
+
+        /**
+         * Constructor with default values.
+         */
+        public MaxLengthStrategy() {
+            this(DEFAULT_REGULAR_ATTRIBUTE_LENGTH, DEFAULT_LARGE_ATTRIBUTES, DEFAULT_LARGE_ATTRIBUTE_LENGTH);
+        }
+
+        /**
+         * Constructor with custom values.
+         *
+         * @param regularAttributeLength length for regular attributes
+         * @param largeAttributes        set of large attributes
+         * @param largeAttributeLength   length for large attributes
+         */
+        public MaxLengthStrategy(int regularAttributeLength, long[] largeAttributes, int largeAttributeLength) {
+            this.largeAttributes = largeAttributes;
+            this.regularAttributeLength = regularAttributeLength;
+            this.largeAttributeLength = largeAttributeLength;
+        }
+
+        @Override
+        public int getAttributeLength(long cka) {
+            if (contains(largeAttributes, cka)) {
+                return largeAttributeLength;
+            } else {
+                return regularAttributeLength;
+            }
+        }
+
+        // simple check if array contains value
+        private static boolean contains(long[] array, long value) {
+            for (long l : array) {
+                if (l == value) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Strategy for querying length of attribute value in C_GetAttributeValue request
+     * for every attribute.
+     */
+    class IndefiniteLengthStrategy implements AttributeLengthStrategy {
+        @Override
+        public int getAttributeLength(long cka) {
+            return 0;
+        }
+    }
+}

--- a/src/main/java/org/pkcs11/jacknji11/CE.java
+++ b/src/main/java/org/pkcs11/jacknji11/CE.java
@@ -1582,4 +1582,12 @@ public class CE {
         System.arraycopy(buf, 0, result, 0, result.length);
         return result;
     }
+
+    /**
+     * Obtain metrics for calls on underlying {@link NativeProvider}
+     * @return metrics object
+     */
+    public static NativeProviderMetrics getMetrics() {
+        return CRYPTOKIE.getMetrics();
+    }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CE.java
+++ b/src/main/java/org/pkcs11/jacknji11/CE.java
@@ -59,7 +59,7 @@ package org.pkcs11.jacknji11;
  */
 public class CE {
 
-    private static CryptokiE CRYPTOKIE;
+    static CryptokiE CRYPTOKIE;
 
     /**
      * Initialize cryptoki.

--- a/src/main/java/org/pkcs11/jacknji11/CK.java
+++ b/src/main/java/org/pkcs11/jacknji11/CK.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2011 Joel Hockey (joel.hockey@gmail.com). All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.pkcs11.jacknji11;
+
+/**
+ * PKCS#11 CK_? constants.
+ *
+ * @author Tomasz Wysocki
+ */
+public class CK {
+
+    /**
+     * Value of invalid handles.
+     */
+    public static final long INVALID_HANDLE = 0x00000000L;
+
+    /**
+     * Value of infinite used for max session counts.
+     */
+    public static final long EFFECTIVELY_INFINITE = 0x00000000L;
+
+    /**
+     * Value returned in <code>ulValueLen</code> when attribute is not available.
+     */
+    public static final long UNAVAILABLE_INFORMATION = -1L;
+
+}

--- a/src/main/java/org/pkcs11/jacknji11/CKA.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKA.java
@@ -30,6 +30,57 @@ import org.apache.commons.logging.LogFactory;
 
 /**
  * CKA_? constants and wrapper for CK_ATTRIBUTE struct.
+ * <p>
+ * Generally the state of attribute depends on whether it before or after reading the value from PKCS#11.
+ * We distinguish that by <code>{@link #isSet}</code> flag. The same values of other
+ * fields can have different meanings depending on the state of this flag.
+ * <p>
+ * The attribute can be in one of the following states:
+ *
+ * <ul>
+ *     <li>
+ *         <b>INDEFINITE</b> when the attribute is not yet set and its lengths is unknown, also there is no buffer allocated.
+ *         ulValueLen = 0
+ *         pValue = null
+ *         isSet = false
+ *     </li>
+ *     <li>
+ *         <b>ALLOCATED</b> when the attribute is not yet set but a buffer is allocated to receive data of known length.
+ *         ulValueLen = BUFFERLEN
+ *         pValue = new byte[BUFFERLEN]
+ *         isSet = false
+ *     </li>
+ *     <li>
+ *         <b>DEFINITE</b> when the attribute is set and its length is known but the value is not yet set (pValue is null)
+ *         because the buffer has not been allocated.
+ *         ulValueLen != 0
+ *         pValue = null
+ *         isSet = true
+ *     </li>
+ *     <li>
+ *         <b>HAS_VALUE</b> when the attribute is set and its length is known and the value is set.
+ *         ulValueLen = LEN // LEN > 0
+ *         pValue = new byte[BUFFERLEN] // where BUFFERLEN >= LEN
+ *         isSet = true
+ *     </li>
+ *     <li>
+ *        <b>EMPTY</b> when the attribute is set and its length is known to be 0, irrespective of whether the
+ *        buffer had been allocated or not.
+ *        ulValueLen = 0
+ *        pValue = new byte[BUFFERLEN] or null
+ *        isSet = true
+ *     </li>
+ *     <li>
+ *        <b>INVALID</b> when the attribute is known to not be present in the object or if it is sensitive,
+ *        therefore its value cannot be read.
+ *        ulValueLen = CK.UNAVAILABLE_INFORMATION // -1
+ *        isSet = ?
+ *        pValue = ?
+ *     </li>
+ * </ul>
+ *
+ * Note: attribute that is INVALID is not the same as attribute that is EMPTY. INVALID means that the attribute
+ * is not present in the object or is sensitive. EMPTY means that the attribute is valid but has no actual value.
  *
  * @author Joel Hockey (joel.hockey@gmail.com)
  */
@@ -212,10 +263,16 @@ public class CKA {
     public long type;
     public byte[] pValue;
     public long ulValueLen;
+    /**
+     * Indicates that attribute is actually set.
+     * <p>
+     * This is used when creating new objects which contain a zeroized byte array as a receiving buffer but
+     * are not yet populated with actual data.
+     */
+    private boolean isSet;
 
-    // disallow zero-arg constructor
-    @SuppressWarnings("unused")
-    private CKA() {
+    private CKA(long type) {
+        this.type = type;
     }
 
     /**
@@ -249,25 +306,86 @@ public class CKA {
         } else {
             throw new RuntimeException("Unknown att type: " + value.getClass());
         }
+        isSet = true;
     }
 
     /**
      * PKCS#11 CK_ATTRIBUTE struct constructor with null value.
+     * <p>
+     * Use this variant to create an empty attribute with initial buffer to receive data.
      *
      * @param type
      *            CKA_? type. Use one of the public static final long fields in this class.
+     *
+     * @param size 
+     *            initial buffer size, if 0 then no buffer is allocated
+     * @return an unset attribute with buffer of given size            
      */
-    public CKA(long type) {
-        this(type, null);
+    public static CKA allocate(long type, int size) {
+        CKA cka = new CKA(type);
+        cka.pValue = size > 0 ? new byte[size] : null;
+        cka.ulValueLen = size;
+        return cka;
+    }
+
+    /**
+     * Prepare an empty unset attribute to receive length of value.
+     * 
+     * @param type CKA_? type. Use one of the public static final long fields in this class.
+     *             
+     * @return an unset attribute with buffer of size 0 to receive length of value
+     */
+    public static CKA indefinite(long type) {
+        return allocate(type, 0);
+    }
+
+    /**
+     * Returns true if the attribute has a non-empty value.
+     * <p>
+     * Note: see HAS_VALUE state description in class javadoc.
+     * @return true if the attribute has a non-empty value set, false otherwise
+     */
+    public boolean hasValue() {
+        // the last condition shall not arise, however if buffer too short error is indicated
+        // by the implementation that does not set CK.UNAVAILABLE_INFORMATION in ulValueLen
+        return isSet && ulValueLen > 0 && pValue != null && pValue.length >= ulValueLen;
+    }
+
+    /**
+     * Check if value is invalid.
+     */
+    public boolean isInvalid() {
+        return ulValueLen == CK.UNAVAILABLE_INFORMATION;
+    }
+
+    /**
+     * Check if value is empty.
+     */
+    public boolean isEmpty() {
+        return isSet && ulValueLen == 0;
+    }
+
+    /**
+     * Check if value has been set by PKCS#11 provider.
+     */
+    public boolean isSet() {
+        return isSet;
+    }
+
+    /**
+     * Mark this attribute as set.
+     */
+    public void set() {
+        this.isSet = true;
     }
 
     /** When reading values from PKCS#11 you often send a buffer, with a specific length
      * where the buffer may be lager than the value returned. The actual length of the value returned
      * is then put by the HSM in ulValueLen. Before returning to Java, therefore make sure 
-     * the returned pValue hodls the actual bytes and not extra (empty) data.
+     * the returned pValue holds the actual bytes and not extra (empty) data.
      */
     private byte[] getValueInternal() {
-        return ulValueLen == 0 || pValue == null ? null : Buf.substring(pValue, 0, (int)ulValueLen);
+        return hasValue() ? Buf.substring(pValue, 0, (int) ulValueLen) : null;
     }
     /** @return value as byte[] */
     public byte[] getValue() {
@@ -276,12 +394,12 @@ public class CKA {
 
     /** @return value as String */
     public String getValueStr() {
-        return pValue == null ? null : new String(getValueInternal());
+        return hasValue() ? new String(getValueInternal()) : null;
     }
 
     /** @return value as Long */
     public Long getValueLong() {
-        if (ulValueLen == 0 || pValue == null) {
+        if (!hasValue()) {
             return null;
         }
         if (ulValueLen != ULong.ULONG_SIZE.size()) {
@@ -295,7 +413,7 @@ public class CKA {
 
     /** @return value as boolean */
     public Boolean getValueBool() {
-        if (ulValueLen == 0 || pValue == null) {
+        if (!hasValue()) {
             return null;
         }
         if (ulValueLen != 1) {
@@ -309,7 +427,7 @@ public class CKA {
 
     /** @return value as BigInteger */
     public BigInteger getValueBigInt() {
-        return ulValueLen == 0 || pValue == null ? null : new BigInteger(1, Buf.substring(pValue, 0, (int)ulValueLen));
+        return hasValue() ? UBigInt.b2ubigint(getValueInternal()) : null;
     }
 
     /**
@@ -319,13 +437,22 @@ public class CKA {
      *            write to
      */
     public void dump(StringBuilder sb) {
-        sb.append(String.format("type=0x%08x{%s} valueLen=%d", type, L2S(type), ulValueLen));
+        sb.append(String.format("type=0x%08x{%s} ", type, L2S(type)));
+
+        dumpState(sb);
+
+        if (hasValue()) {
+            dumpValue(sb);
+        }
+    }
+
+    private void dumpValue(StringBuilder sb) {
 
         try {
             switch ((int) type) {
             case (int) CLASS: // lookup CKO
                 Long cko = getValueLong();
-                sb.append(String.format(" value=0x%08x{%s}", type, cko != null ? CKO.L2S(cko) : "null"));
+                sb.append(String.format(" value=0x%08x{%s}", cko != null ? cko : -1, cko != null ? CKO.L2S(cko) : "null"));
                 return;
             case (int) TOKEN: // boolean
             case (int) PRIVATE:
@@ -378,11 +505,11 @@ public class CKA {
                 return;
             case (int) CERTIFICATE_TYPE: // lookup CKC
                 Long ckc = getValueLong();
-                sb.append(String.format(" value=0x%08x{%s}", type, ckc != null ? CKC.L2S(ckc) : "null"));
+                sb.append(String.format(" value=0x%08x{%s}", ckc != null ? ckc : -1, ckc != null ? CKC.L2S(ckc) : "null"));
                 return;
             case (int) KEY_TYPE: // lookup CKK
                 Long ckk = getValueLong();
-                sb.append(String.format(" value=0x%08x{%s}", type, ckk != null ? CKK.L2S(ckk) : "null"));
+                sb.append(String.format(" value=0x%08x{%s}", ckk != null ? ckk : -1, ckk != null ? CKK.L2S(ckk) : "null"));
                 return;
             case (int) MODULUS_BITS: // long
             case (int) PRIME_BITS:
@@ -429,6 +556,37 @@ public class CKA {
         Hex.dump(sb, value, 0, (int) ulValueLen, "    ", 32, false);
     }
 
+    /**
+     * Dump the state of attribute according to the state description in class javadoc.
+     *
+     * @param sb the StringBuilder to append to
+     */
+    private void dumpState(StringBuilder sb) {
+        if (isSet) {
+            if (ulValueLen == 0) {
+                sb.append(" EMPTY");
+            } else if (ulValueLen == -1) {
+                sb.append(" INVALID");
+            } else {
+                if (pValue == null) {
+                    sb.append(" DEFINITE");
+                }
+                sb.append(String.format(" [%dB]", ulValueLen));
+            }
+        } else {
+            if (ulValueLen == 0) {
+                sb.append(" INDEFINITE");
+            } else if (ulValueLen == -1) {
+                sb.append(" INVALID");
+            } else {
+                if (pValue != null) {
+                    sb.append(" ALLOCATED");
+                }
+                sb.append(String.format(" [%dB]", ulValueLen));
+            }
+        }
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -440,9 +598,12 @@ public class CKA {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + Arrays.hashCode(pValue);
         result = prime * result + (int) (type ^ (type >>> 32));
         result = prime * result + (int) (ulValueLen ^ (ulValueLen >>> 32));
+        result = prime * result + (isSet ? 1231 : 1237);
+        if (isSet) {
+            result = prime * result + Arrays.hashCode(getValueInternal());
+        }
         return result;
     }
 
@@ -455,11 +616,13 @@ public class CKA {
         if (getClass() != obj.getClass())
             return false;
         CKA other = (CKA) obj;
-        if (!Arrays.equals(pValue, other.pValue))
+        if (ulValueLen != other.ulValueLen)
             return false;
         if (type != other.type)
             return false;
-        if (ulValueLen != other.ulValueLen)
+        if (isSet != other.isSet)
+            return false;
+        if (isSet && !Arrays.equals(getValueInternal(), other.getValueInternal()))
             return false;
         return true;
     }

--- a/src/main/java/org/pkcs11/jacknji11/CKA.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKA.java
@@ -238,7 +238,7 @@ public class CKA {
             pValue = (byte[]) value;
             ulValueLen = pValue.length;
         } else if (value instanceof BigInteger) {
-            byte[] pValue = ((BigInteger) value).toByteArray();
+            this.pValue = UBigInt.ubigint2b((BigInteger) value);
             ulValueLen = pValue.length;
         } else if (value instanceof Number) {
             pValue = ULong.ulong2b(((Number) value).longValue());
@@ -309,7 +309,7 @@ public class CKA {
 
     /** @return value as BigInteger */
     public BigInteger getValueBigInt() {
-        return ulValueLen == 0 || pValue == null ? null : new BigInteger(Buf.substring(pValue, 0, (int)ulValueLen));
+        return ulValueLen == 0 || pValue == null ? null : new BigInteger(1, Buf.substring(pValue, 0, (int)ulValueLen));
     }
 
     /**

--- a/src/main/java/org/pkcs11/jacknji11/CKC.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKC.java
@@ -35,11 +35,11 @@ public class CKC {
     public static final long CKC_VENDOR_DEFINED  = 0x80000000;
 
     /** Maps from long value to String description (variable name). */
-    private static final Map<Long, String> L2S = C.createL2SMap(CKS.class);
+    private static final Map<Long, String> L2S = C.createL2SMap(CKC.class);
     /**
      * Convert long constant value to name.
-     * @param cks value
+     * @param ckc value
      * @return name
      */
-    public static final String L2S(long cks) { return C.l2s(L2S, CKS.class.getSimpleName(), cks); }
+    public static final String L2S(long ckc) { return C.l2s(L2S, CKC.class.getSimpleName(), ckc); }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CKD.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKD.java
@@ -32,6 +32,28 @@ public class CKD {
     public static final long SHA1_KDF                = 0x00000002;
     public static final long SHA1_KDF_ASN1           = 0x00000003;
     public static final long SHA1_KDF_CONCATENATE    = 0x00000004;
+    public static final long SHA224_KDF              = 0x00000005;
+    public static final long SHA256_KDF              = 0x00000006;
+    public static final long SHA384_KDF              = 0x00000007;
+    public static final long SHA512_KDF              = 0x00000008;
+    public static final long CPDIVERSIFY_KDF         = 0x00000009;
+    public static final long SHA3_224_KDF            = 0x0000000A;
+    public static final long SHA3_256_KDF            = 0x0000000B;
+    public static final long SHA3_384_KDF            = 0x0000000C;
+    public static final long SHA3_512_KDF            = 0x0000000D;
+    public static final long SHA1_KDF_SP800          = 0x0000000E;
+    public static final long SHA224_KDF_SP800        = 0x0000000F;
+    public static final long SHA256_KDF_SP800        = 0x00000010;
+    public static final long SHA384_KDF_SP800        = 0x00000011;
+    public static final long SHA512_KDF_SP800        = 0x00000012;
+    public static final long SHA3_224_KDF_SP800      = 0x00000013;
+    public static final long SHA3_256_KDF_SP800      = 0x00000014;
+    public static final long SHA3_384_KDF_SP800      = 0x00000015;
+    public static final long SHA3_512_KDF_SP800      = 0x00000016;
+    public static final long BLAKE2B_160_KDF         = 0x00000017;
+    public static final long BLAKE2B_256_KDF         = 0x00000018;
+    public static final long BLAKE2B_384_KDF         = 0x00000019;
+    public static final long BLAKE2B_512_KDF         = 0x0000001a;
 
     /** Maps from long value to String description (variable name). */
     private static final Map<Long, String> L2S = C.createL2SMap(CKD.class);

--- a/src/main/java/org/pkcs11/jacknji11/CKM.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKM.java
@@ -389,11 +389,22 @@ public class CKM {
      * PKCS#11 CK_MECHANISM struct constructor.
      * @param mechanism CKM_? mechanism.  Use one of the public static final long fields in this class.
      * @param param param for mechanism
+     * @param paramSize size of param
      */
-    public CKM(long mechanism, Pointer param, int paramSize) {
+    public CKM(long mechanism, Pointer param, long paramSize) {
         this.mechanism = mechanism;
         this.pParameter = param;
-        ulParameterLen = paramSize;
+        this.ulParameterLen = paramSize;
+    }
+
+    /**
+     * PKCS#11 CK_MECHANISM struct constructor.
+     *
+     * @param mechanism CKM_? mechanism.  Use one of the public static final long fields in this class.
+     * @param memory memory containing param for mechanism
+     */
+    public CKM(long mechanism, Memory memory) {
+        this(mechanism, memory, memory.size());
     }
 
     public CKM(long mechanism, byte[] param) {    
@@ -417,7 +428,7 @@ public class CKM {
     /** @return string */
     public String toString() {
         return String.format("mechanism=0x%08x{%s} paramLen=%d param=%s",
-            mechanism, L2S(mechanism), bParameter != null ? bParameter.length : 0, 
-                    Hex.b2s(bParameter));
+            mechanism, L2S(mechanism), ulParameterLen,
+                    pParameter != null ? Hex.b2s(pParameter.getByteArray(0, (int) ulParameterLen)) : "null");
     }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CKM.java
+++ b/src/main/java/org/pkcs11/jacknji11/CKM.java
@@ -86,6 +86,8 @@ public class CKM {
     public static final long DES3_MAC                    = 0x00000134;
     public static final long DES3_MAC_GENERAL            = 0x00000135;
     public static final long DES3_CBC_PAD                = 0x00000136;
+    public static final long DES3_CMAC_GENERAL           = 0x00000137;
+    public static final long DES3_CMAC                   = 0x00000138;
     public static final long CDMF_KEY_GEN                = 0x00000140;
     public static final long CDMF_ECB                    = 0x00000141;
     public static final long CDMF_CBC                    = 0x00000142;
@@ -114,6 +116,9 @@ public class CKM {
     public static final long SHA256                      = 0x00000250;
     public static final long SHA256_HMAC                 = 0x00000251;
     public static final long SHA256_HMAC_GENERAL         = 0x00000252;
+    public static final long SHA224                      = 0x00000255;
+    public static final long SHA224_HMAC                 = 0x00000256;
+    public static final long SHA224_HMAC_GENERAL         = 0x00000257;
     public static final long SHA384                      = 0x00000260;
     public static final long SHA384_HMAC                 = 0x00000261;
     public static final long SHA384_HMAC_GENERAL         = 0x00000262;
@@ -184,6 +189,7 @@ public class CKM {
     public static final long SHA256_KEY_DERIVATION       = 0x00000393;
     public static final long SHA384_KEY_DERIVATION       = 0x00000394;
     public static final long SHA512_KEY_DERIVATION       = 0x00000395;
+    public static final long SHA224_KEY_DERIVATION       = 0x00000396;
     public static final long PBE_MD2_DES_CBC             = 0x000003a0;
     public static final long PBE_MD5_DES_CBC             = 0x000003a1;
     public static final long PBE_MD5_CAST_CBC            = 0x000003a2;
@@ -198,6 +204,9 @@ public class CKM {
     public static final long PBE_SHA1_DES2_EDE_CBC       = 0x000003a9;
     public static final long PBE_SHA1_RC2_128_CBC        = 0x000003aa;
     public static final long PBE_SHA1_RC2_40_CBC         = 0x000003ab;
+    public static final long SP800_108_COUNTER_KDF       = 0x000003ac;
+    public static final long SP800_108_FEEDBACK_KDF      = 0x000003ad;
+    public static final long SP800_108_DOUBLE_PIPELINE_KDF = 0x000003ae;
     public static final long PKCS5_PBKD2                 = 0x000003b0;
     public static final long PBA_SHA1_WITH_SHA1_HMAC     = 0x000003c0;
     public static final long WTLS_PRE_MASTER_KEY_GEN     = 0x000003d0;
@@ -270,12 +279,23 @@ public class CKM {
     public static final long JUNIPER_SHUFFLE             = 0x00001064;
     public static final long JUNIPER_WRAP                = 0x00001065;
     public static final long FASTHASH                    = 0x00001070;
+    public static final long AES_XTS                     = 0x00001071;
+    public static final long AES_XTS_KEY_GEN             = 0x00001072;
     public static final long AES_KEY_GEN                 = 0x00001080;
     public static final long AES_ECB                     = 0x00001081;
     public static final long AES_CBC                     = 0x00001082;
     public static final long AES_MAC                     = 0x00001083;
     public static final long AES_MAC_GENERAL             = 0x00001084;
     public static final long AES_CBC_PAD                 = 0x00001085;
+    public static final long AES_CTR                     = 0x00001086;
+    public static final long AES_GCM                     = 0x00001087;
+    public static final long AES_CCM                     = 0x00001088;
+    public static final long AES_CTS                     = 0x00001089;
+    public static final long AES_CMAC                    = 0x0000108A;
+    public static final long AES_CMAC_GENERAL            = 0x0000108B;
+    public static final long CKM_AES_XCBC_MAC            = 0x0000108C;
+    public static final long CKM_AES_XCBC_MAC_96         = 0x0000108D;
+    public static final long CKM_AES_GMAC                = 0x0000108E;
     public static final long DES_ECB_ENCRYPT_DATA        = 0x00001100;
     public static final long DES_CBC_ENCRYPT_DATA        = 0x00001101;
     public static final long DES3_ECB_ENCRYPT_DATA       = 0x00001102;
@@ -286,6 +306,9 @@ public class CKM {
     public static final long DSA_PARAMETER_GEN           = 0x00002000;
     public static final long DH_PKCS_PARAMETER_GEN       = 0x00002001;
     public static final long X9_42_DH_PARAMETER_GEN      = 0x00002002;
+
+    public static final long CKM_AES_KEY_WRAP            = 0x00002109;
+    public static final long CKM_AES_KEY_WRAP_PAD        = 0x0000210a;
 
     // From PKCS#11 version 3.0
     public static final long EC_EDWARDS_KEY_PAIR_GEN = 0x00001055;

--- a/src/main/java/org/pkcs11/jacknji11/Cryptoki.java
+++ b/src/main/java/org/pkcs11/jacknji11/Cryptoki.java
@@ -74,18 +74,24 @@ public class Cryptoki {
     private final NativeProvider provider;
 
     /**
+     * Metrics for {@link #provider} calls.
+     */
+    private final NativeProviderMetrics metrics = new NativeProviderMetrics();
+
+    /**
      * Default constructor uses {@link org.pkcs11.jacknji11.jna.JNA}
      * {@link org.pkcs11.jacknji11.NativeProvider}.
      */
     public Cryptoki() {
-        this.provider = new JNA();
+        this(new JNA());
     }
 
     /**
      * @param provider cryptoki {@link org.pkcs11.jacknji11.NativeProvider}.
      */
     public Cryptoki(NativeProvider provider) {
-        this.provider = provider != null ? provider : new JNA();
+        NativeProvider p = provider != null ? provider : new JNA();
+        this.provider = this.metrics.intercept(p);
     }
 
     /**
@@ -1395,5 +1401,14 @@ public class Cryptoki {
             sb.append("\n  ");
             template[i].dump(sb);
         }
+    }
+
+    /**
+     * Obtain metrics on calls to the underlying {@link NativeProvider}
+     *
+     * @return metrics object
+     */
+    public NativeProviderMetrics getMetrics() {
+        return metrics;
     }
 }

--- a/src/main/java/org/pkcs11/jacknji11/Cryptoki.java
+++ b/src/main/java/org/pkcs11/jacknji11/Cryptoki.java
@@ -21,11 +21,7 @@
 
 package org.pkcs11.jacknji11;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -365,7 +361,7 @@ public class Cryptoki {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_GetOperationState rv=0x%08x{%s}\n  operationState (len=%d):\n", rv, CKR.L2S(rv), operationStateLen.value()));
             if (operationState != null) {
-                Hex.dump(sb, operationState, 0, (int) operationStateLen.value(), "  ", 32, false);
+                hexDumpOut(rv, sb, operationState, (int) operationStateLen.value());
             }
             log.debug(sb);
         }
@@ -388,7 +384,7 @@ public class Cryptoki {
             StringBuilder sb = new StringBuilder(String.format(
                     "> C_SetOperationState session=0x%08x encryptionKey=0x%08x authenticationKey=0x%08x\n  operationState (len=%d):\n",
                     session, encryptionKey, authenticationKey, operationState.length));
-            Hex.dump(sb, operationState, 0, operationState.length, "  ", 32, false);
+            hexDump(sb, operationState, operationState.length);
             log.debug(sb);
         }
         long rv = provider.C_SetOperationState(session, operationState, baLen(operationState),
@@ -618,13 +614,13 @@ public class Cryptoki {
     public long Encrypt(long session, byte[] data, byte[] encryptedData, LongRef encryptedDataLen) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_Encrypt session=0x%08x encryptedDataLen=%d data\n  (len=%d):\n", session, encryptedDataLen.value(), data.length));
-            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
+            hexDump(sb, data, data.length);
             log.debug(sb);
         }
         long rv = provider.C_Encrypt(session, data, baLen(data), encryptedData, encryptedDataLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_Encrypt rv=0x%08x{%s}\n  encryptedData (len=%d):\n", rv, CKR.L2S(rv), encryptedDataLen.value()));
-            Hex.dump(sb, encryptedData, 0, (int) encryptedDataLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, encryptedData, (int) encryptedDataLen.value());
             log.debug(sb);
         }
         return rv;
@@ -642,13 +638,13 @@ public class Cryptoki {
     public long EncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_EncryptUpdate session=0x%08x encryptedPartLen=%d\n  part (len=%d):\n", session, encryptedPartLen.value(), part.length));
-            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
+            hexDump(sb, part, part.length);
             log.debug(sb);
         }
         long rv = provider.C_EncryptUpdate(session, part, baLen(part), encryptedPart, encryptedPartLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_EncryptUpdate rv=0x%08x{%s}\n  encryptedPart (len=%d):\n", rv, CKR.L2S(rv), encryptedPartLen.value()));
-            Hex.dump(sb, encryptedPart, 0, (int) encryptedPartLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, encryptedPart, (int) encryptedPartLen.value());
             log.debug(sb);
         }
         return rv;
@@ -667,7 +663,7 @@ public class Cryptoki {
         long rv = provider.C_EncryptFinal(session, lastEncryptedPart, lastEncryptedPartLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_EncryptFinal rv=0x%08x{%s}\n  lastEncryptedPart (len=%d):\n", rv, CKR.L2S(rv), lastEncryptedPartLen.value()));
-            Hex.dump(sb, lastEncryptedPart, 0, (int) lastEncryptedPartLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, lastEncryptedPart, (int) lastEncryptedPartLen.value());
             log.debug(sb);
         }
         return rv;
@@ -700,13 +696,13 @@ public class Cryptoki {
     public long Decrypt(long session, byte[] encryptedData, byte[] data, LongRef dataLen) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_Decrypt session=0x%08x dataLen=%d\n encryptedData (len=%d):\n", session, dataLen.value(), encryptedData.length));
-            Hex.dump(sb, encryptedData, 0, encryptedData.length, "  ", 32, false);
+            hexDump(sb, encryptedData, encryptedData.length);
             log.debug(sb);
         }
         long rv = provider.C_Decrypt(session, encryptedData, baLen(encryptedData), data, dataLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_Decrypt rv=0x%08x{%s}\n  data (len=%d):\n", rv, CKR.L2S(rv), dataLen.value()));
-            Hex.dump(sb, data, 0, (int) dataLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, data, (int) dataLen.value());
             log.debug(sb);
         }
         return rv;
@@ -724,13 +720,13 @@ public class Cryptoki {
     public long DecryptUpdate(long session, byte[] encryptedPart, byte[] data, LongRef dataLen) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_DecryptUpdate session=0x%08x dataLen=%d\n  encryptedPart (len=%d):\n", session, dataLen.value(), encryptedPart.length));
-            Hex.dump(sb, encryptedPart, 0, encryptedPart.length, "  ", 32, false);
+            hexDump(sb, encryptedPart, encryptedPart.length);
             log.debug(sb);
         }
         long rv = provider.C_DecryptUpdate(session, encryptedPart, baLen(encryptedPart), data, dataLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_DecryptUpdate rv=0x%08x{%s}\n  data (len=%d):\n", rv, CKR.L2S(rv), dataLen.value()));
-            Hex.dump(sb, data, 0, (int) dataLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, data, (int) dataLen.value());
             log.debug(sb);
         }
         return rv;
@@ -749,7 +745,7 @@ public class Cryptoki {
         long rv = provider.C_DecryptFinal(session, lastPart, lastPartLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_DecryptFinal rv=0x%08x{%s}\n  lastPart (len=%d):\n", rv, CKR.L2S(rv), lastPartLen.value()));
-            Hex.dump(sb, lastPart, 0, (int) lastPartLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, lastPart, (int) lastPartLen.value());
             log.debug(sb);
         }
         return rv;
@@ -781,13 +777,13 @@ public class Cryptoki {
     public long Digest(long session, byte[] data, byte[] digest, LongRef digestLen) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_Digest session=0x%08x digestLen=%d\n  data (len=%d):\n", session, digestLen.value(), data.length));
-            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
+            hexDump(sb, data, data.length);
             log.debug(sb);
         }
         long rv = provider.C_Digest(session, data, baLen(data), digest, digestLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_Digest rv=0x%08x{%s}\n  digest (len=%d):\n", rv, CKR.L2S(rv), digestLen.value()));
-            Hex.dump(sb, digest, 0, (int) digestLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, digest, (int) digestLen.value());
             log.debug(sb);
         }
         return rv;
@@ -803,7 +799,7 @@ public class Cryptoki {
     public long DigestUpdate(long session, byte[] part) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_DigestUpdate session=0x%08x\n  part (len=%d):\n", session, part.length));
-            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
+            hexDump(sb, part, part.length);
             log.debug(sb);
         }
         long rv = provider.C_DigestUpdate(session, part, baLen(part));
@@ -839,7 +835,7 @@ public class Cryptoki {
         long rv = provider.C_DigestFinal(session, digest, digestLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_DigestFinal rv=0x%08x{%s}\n  digest (len=%d):\n", rv, CKR.L2S(rv), digestLen.value()));
-            Hex.dump(sb, digest, 0, (int) digestLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, digest, (int) digestLen.value());
             log.debug(sb);
         }
         return rv;
@@ -875,13 +871,13 @@ public class Cryptoki {
     public long Sign(long session, byte[] data, byte[] signature, LongRef signatureLen) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_Sign session=0x%08x signatureLen=%d\n  data (len=%d):\n", session, signatureLen.value(), data.length));
-            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
+            hexDump(sb, data, data.length);
             log.debug(sb);
         }
         long rv = provider.C_Sign(session, data, baLen(data), signature, signatureLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_Sign rv=0x%08x{%s}\n  signature (len=%d):\n", rv, CKR.L2S(rv), signatureLen.value()));
-            Hex.dump(sb, signature, 0, (int) signatureLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, signature, (int) signatureLen.value());
             log.debug(sb);
         }
         return rv;
@@ -899,7 +895,7 @@ public class Cryptoki {
     public long SignUpdate(long session, byte[] part) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_SignUpdate session=0x%08x\n  part (len=%d):\n", session, part.length));
-            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
+            hexDump(sb, part, part.length);
             log.debug(sb);
         }
         long rv = provider.C_SignUpdate(session, part, baLen(part));
@@ -920,7 +916,7 @@ public class Cryptoki {
         long rv = provider.C_SignFinal(session, signature, signatureLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_SignFinal rv=0x%08x{%s}\n  signature (len=%d):\n", rv, CKR.L2S(rv), signatureLen.value()));
-            Hex.dump(sb, signature, 0, (int) signatureLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, signature, (int) signatureLen.value());
             log.debug(sb);
         }
         return rv;
@@ -953,13 +949,13 @@ public class Cryptoki {
     public long SignRecover(long session, byte[] data, byte[] signature, LongRef signatureLen) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_SignRecover session=0x%08x signatureLen=%d\n  data (len=%d):\n", session, signatureLen.value(), data.length));
-            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
+            hexDump(sb, data, data.length);
             log.debug(sb);
         }
         long rv = provider.C_SignRecover(session, data, baLen(data), signature, signatureLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_SignRecover rv=0x%08x{%s}\n  signature (len=%d):\n", rv, CKR.L2S(rv), signatureLen.value()));
-            Hex.dump(sb, signature, 0, (int) signatureLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, signature, (int) signatureLen.value());
             log.debug(sb);
         }
         return rv;
@@ -993,9 +989,9 @@ public class Cryptoki {
     public long Verify(long session, byte[] data, byte[] signature) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_Verify session=0x%08x\n  data (len=%d):\n", session, data.length));
-            Hex.dump(sb, data, 0, data.length, "  ", 32, false);
+            hexDump(sb, data, data.length);
             sb.append(String.format("\n  signature (len=%d):\n", signature.length));
-            Hex.dump(sb, signature, 0, signature.length, "  ", 32, false);
+            hexDump(sb, signature, signature.length);
             log.debug(sb);
         }
         long rv = provider.C_Verify(session, data, baLen(data), signature, baLen(signature));
@@ -1014,7 +1010,7 @@ public class Cryptoki {
     public long VerifyUpdate(long session, byte[] part) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_VerifyUpdate session=0x%08x\n  part (len=%d):\n", session, part.length));
-            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
+            hexDump(sb, part, part.length);
             log.debug(sb);
         }
         long rv = provider.C_VerifyUpdate(session, part, baLen(part));
@@ -1032,7 +1028,7 @@ public class Cryptoki {
     public long VerifyFinal(long session, byte[] signature) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_VerifyFinal session=0x%08x\n  signature (len=%d):\n", session, signature.length));
-            Hex.dump(sb, signature, 0, signature.length, "  ", 32, false);
+            hexDump(sb, signature, signature.length);
             log.debug(sb);
         }
         long rv = provider.C_VerifyFinal(session, signature, baLen(signature));
@@ -1067,13 +1063,13 @@ public class Cryptoki {
     public long VerifyRecover(long session, byte[] signature, byte[] data, LongRef dataLen) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_VerifyRecover session=0x%08x dataLen=%d\n  signature (len=%d):\n", session, dataLen.value(), signature.length));
-            Hex.dump(sb, signature, 0, signature.length, "  ", 32, false);
+            hexDump(sb, signature, signature.length);
             log.debug(sb);
         }
         long rv = provider.C_VerifyRecover(session, signature, baLen(signature), data, dataLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_VerifyRecover rv=0x%08x{%s}\n  data (len=%d):\n", rv, CKR.L2S(rv), dataLen.value()));
-            Hex.dump(sb, data, 0, (int) dataLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, data, (int) dataLen.value());
             log.debug(sb);
         }
         return rv;
@@ -1091,14 +1087,14 @@ public class Cryptoki {
     public long DigestEncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_DigestEncryptUpdate session=0x%08x encryptedPartLen=%d\n  part (len=%d):\n", session, encryptedPartLen, part.length));
-            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
+            hexDump(sb, part, part.length);
             log.debug(sb);
         }
         long rv = provider.C_DigestEncryptUpdate(session, part, baLen(part),
                 encryptedPart, encryptedPartLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_DigestEncryptUpdate rv=0x%08x{%s}\n  encryptedPart (len=%d):\n", rv, CKR.L2S(rv), encryptedPartLen));
-            Hex.dump(sb, encryptedPart, 0, (int) encryptedPartLen.value, "  ", 32, false);
+            hexDumpOut(rv, sb, encryptedPart, (int) encryptedPartLen.value());
             log.debug(sb);
         }
         return rv;
@@ -1116,14 +1112,14 @@ public class Cryptoki {
     public long DecryptDigestUpdate(long session, byte[] encryptedPart, byte[] part, LongRef partLen) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_DecryptDigestUpdate session=0x%08x partLen=%d\n  encryptedPart (len=%d):\n", session, partLen.value(), encryptedPart.length));
-            Hex.dump(sb, encryptedPart, 0, encryptedPart.length, "  ", 32, false);
+            hexDump(sb, encryptedPart, encryptedPart.length);
             log.debug(sb);
         }
         long rv = provider.C_DecryptDigestUpdate(session,
                 encryptedPart, baLen(encryptedPart), part, partLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_DecryptDigestUpdate rv=0x%08x{%s}\n  part (len=%d):\n", rv, CKR.L2S(rv), partLen.value()));
-            Hex.dump(sb, part, 0, (int) partLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, part, (int) partLen.value());
             log.debug(sb);
         }
         return rv;
@@ -1141,14 +1137,14 @@ public class Cryptoki {
     public long SignEncryptUpdate(long session, byte[] part, byte[] encryptedPart, LongRef encryptedPartLen) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_SignEncryptUdate session=0x%08x encryptedPartLen=%d\n  part (len=%d):\n", session, encryptedPartLen.value(), part.length));
-            Hex.dump(sb, part, 0, part.length, "  ", 32, false);
+            hexDump(sb, part, part.length);
             log.debug(sb);
         }
         long rv = provider.C_SignEncryptUpdate(session, part, baLen(part),
                 encryptedPart, encryptedPartLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_SignEncryptUpdate rv=0x%08x{%s}\n  encryptedPart (len=%d):\n", rv, CKR.L2S(rv), encryptedPartLen.value()));
-            Hex.dump(sb, encryptedPart, 0, (int) encryptedPartLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, encryptedPart, (int) encryptedPartLen.value());
             log.debug(sb);
         }
         return rv;
@@ -1166,14 +1162,14 @@ public class Cryptoki {
     public long DecryptVerifyUpdate(long session, byte[] encryptedPart, byte[] part, LongRef partLen) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_DecryptVerifyUpdate session=0x%08x partLen=%d\n  encryptedPart (len=%d):\n", session, partLen.value(), encryptedPart.length));
-            Hex.dump(sb, encryptedPart, 0, encryptedPart.length, "  ", 32, false);
+            hexDump(sb, encryptedPart, encryptedPart.length);
             log.debug(sb);
         }
         long rv = provider.C_DecryptVerifyUpdate(session,
                 encryptedPart, baLen(encryptedPart), part, partLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_DecryptVerifyUpdate rv=0x%08x{%s}\n  part (len=%d):\n", rv, CKR.L2S(rv), partLen.value()));
-            Hex.dump(sb, part, 0, (int) partLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, part, (int) partLen.value());
             log.debug(sb);
         }
         return rv;
@@ -1252,7 +1248,7 @@ public class Cryptoki {
                 key, wrappedKey, wrappedKeyLen);
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_WrapKey rv=0x%08x{%s}\n  wrappedKey (len=%d):\n", rv, CKR.L2S(rv), wrappedKeyLen.value()));
-            Hex.dump(sb, wrappedKey, 0, (int) wrappedKeyLen.value(), "  ", 32, false);
+            hexDumpOut(rv, sb, wrappedKey, (int) wrappedKeyLen.value());
             log.debug(sb);
         }
         return rv;
@@ -1274,7 +1270,7 @@ public class Cryptoki {
 
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_UnwrapKey session=0x%08x unwrappingKey=0x%08x %s\n  wrappedKey (len=%d):\n", session, unwrappingKey, mechanism, wrappedKey.length));
-            Hex.dump(sb, wrappedKey, 0, wrappedKey.length, "  ", 32, false);
+            hexDump(sb, wrappedKey, wrappedKey.length);
             sb.append('\n');
             dumpTemplate(sb, templ);
             log.debug(sb);
@@ -1316,13 +1312,14 @@ public class Cryptoki {
     public long SeedRandom(long session, byte[] seed) {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_SeedRandom session=0x%08x\n  seed (len=%d):\n", session, seed.length));
-            Hex.dump(sb, seed, 0, seed.length, "  ", 32, false);
+            hexDump(sb, seed, seed.length);
             log.debug(sb);
         }
         long rv = provider.C_SeedRandom(session, seed, baLen(seed));
         if (log.isDebugEnabled()) log.debug(String.format("< C_SeedRandom rv=0x%08x{%s}", rv, CKR.L2S(rv)));
         return rv;
     }
+
 
     /**
      * Generates random or pseudo-random data.
@@ -1336,7 +1333,7 @@ public class Cryptoki {
         long rv = provider.C_GenerateRandom(session, randomData, baLen(randomData));
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("< C_GenerateRandom rv=0x%08x{%s}\n  randomData (len=%d):\n", rv, CKR.L2S(rv), randomData.length));
-            Hex.dump(sb, randomData, 0, randomData.length, "  ", 32, false);
+            hexDumpOut(rv, sb, randomData, randomData.length);
             log.debug(sb);
         }
         return rv;
@@ -1400,6 +1397,29 @@ public class Cryptoki {
         for (int i = 0; i < templateLen; i++) {
             sb.append("\n  ");
             template[i].dump(sb);
+        }
+    }
+
+    private static void hexDump(StringBuilder sb, byte[] data, int len) {
+        Hex.dump(sb, data, 0, len, "  ", 32, false);
+    }
+
+    /**
+     * Hex dump data into string builder unless rv is CKR.BUFFER_TOO_SMALL
+     * which is indicated by appending "<buffer too small>" to the string builder.
+     * <p>
+     * Note: it does not make sense to dump data if rv is CKR.BUFFER_TOO_SMALL.
+     *
+     * @param rv return value
+     * @param sb string builder
+     * @param data data to dump
+     * @param dataLen data length
+     */
+    private static void hexDumpOut(long rv, StringBuilder sb, byte[] data, int dataLen) {
+        if (rv != CKR.BUFFER_TOO_SMALL) {
+            hexDump(sb, data, dataLen);
+        } else {
+            sb.append("  <buffer too small>");
         }
     }
 

--- a/src/main/java/org/pkcs11/jacknji11/Cryptoki.java
+++ b/src/main/java/org/pkcs11/jacknji11/Cryptoki.java
@@ -988,7 +988,7 @@ public class Cryptoki {
         if (log.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder(String.format("> C_Verify session=0x%08x\n  data (len=%d):\n", session, data.length));
             Hex.dump(sb, data, 0, data.length, "  ", 32, false);
-            sb.append("\n  signature (len=%d):\n");
+            sb.append(String.format("\n  signature (len=%d):\n", signature.length));
             Hex.dump(sb, signature, 0, signature.length, "  ", 32, false);
             log.debug(sb);
         }

--- a/src/main/java/org/pkcs11/jacknji11/CryptokiE.java
+++ b/src/main/java/org/pkcs11/jacknji11/CryptokiE.java
@@ -1873,4 +1873,12 @@ public class CryptokiE {
         System.arraycopy(buf, 0, result, 0, result.length);
         return result;
     }
+
+    /**
+     * Obtain metrics for calls on underlying {@link NativeProvider}
+     * @return metrics object
+     */
+    public NativeProviderMetrics getMetrics() {
+        return c.getMetrics();
+    }
 }

--- a/src/main/java/org/pkcs11/jacknji11/CryptokiE.java
+++ b/src/main/java/org/pkcs11/jacknji11/CryptokiE.java
@@ -23,7 +23,7 @@ package org.pkcs11.jacknji11;
 
 /**
  * This is the preferred java interface for calling cryptoki functions.
- *
+ * <p>
  * jacknji11 provides 3 interfaces for calling cryptoki functions (plus 2 for
  * backwards compatibility).
  * <ol>
@@ -57,7 +57,30 @@ package org.pkcs11.jacknji11;
  */
 public class CryptokiE {
 
+    /**
+     * Underlying Cryptoki object.
+     */
     private final Cryptoki c;
+
+    /**
+     * Strategy for determining the length of attributes in a GetAttribute process.
+     * <p>
+     * Default: {@link AttributeLengthStrategy.IndefiniteLengthStrategy}
+     *
+     * @see AttributeLengthStrategy.MaxLengthStrategy
+     * @see AttributeLengthStrategy.IndefiniteLengthStrategy
+     */
+    private AttributeLengthStrategy attributeLengthStrategy = new AttributeLengthStrategy.IndefiniteLengthStrategy();
+
+    /**
+     * Flag enabling batch mode for getting attributes.
+     * If <code>true</code>, then all attributes are retrieved in a single call to
+     * <code>C_GetAttributeValue</code>.  If <code>false</code>, then each attribute is
+     * retrieved in a separate call to <code>C_GetAttributeValue</code>.
+     * <p>
+     * Default: true
+     */
+    private boolean attributeBatchModeEnabled = true;
 
     public CryptokiE() {
       this.c = new Cryptoki();
@@ -651,28 +674,8 @@ public class CryptokiE {
      * @see NativeProvider#C_GetAttributeValue(long, long, CKA[], long)
      */
     public CKA GetAttributeValue(long session, long object, long cka) {
-        CKA[] templ = {new CKA(cka)};
-        // first call to get how much memory we must allocate
-        long rv = c.GetAttributeValue(session, object, templ);
-        // PKCS#11 v2.40, section 5.7, C_GetAttributeValue
-        //  Note that the error codes CKR_ATTRIBUTE_SENSITIVE, CKR_ATTRIBUTE_TYPE_INVALID, and CKR_BUFFER_TOO_SMALL 
-        //  do not denote true errors for C_GetAttributeValue.  If a call to C_GetAttributeValue returns any of these 
-        //  three values, then the call MUST nonetheless have processed every attribute in the template supplied to 
-        //  C_GetAttributeValue.  Each attribute in the template whose value can be returned by the call to 
-        //  C_GetAttributeValue will be returned by the call to C_GetAttributeValue.
-        // So we will assume that values are processed and returned, perhaps as 0 length, null values (CK_UNAVAILABLE_INFORMATION)
-        // Unless CKR_BUFFER_TOO_SMALL that actually is something the caller must fix and the caller should be notified
-        if (rv == CKR.ATTRIBUTE_TYPE_INVALID || rv == CKR.ATTRIBUTE_SENSITIVE || templ[0].ulValueLen == 0) {
-            // No value to fetch, so return the empty value (CK_UNAVAILABLE_INFORMATION)
-            return templ[0];
-        }
-        if (rv != CKR.OK) throw new CKRException(rv);
-
-        // allocate memory and call again
-        templ[0].pValue = new byte[(int) templ[0].ulValueLen];
-        rv = c.GetAttributeValue(session, object, templ);
-        if (rv != CKR.OK) throw new CKRException(rv);
-        return templ[0];
+        // the general fetching process optimizes single fetch as well
+        return GetAttributeValue(session, object, new long[] { cka })[0];
     }
 
     /**
@@ -689,21 +692,8 @@ public class CryptokiE {
         if (types == null || types.length == 0) {
             return new CKA[0];
         }
-        CKA[] templ = new CKA[types.length];
-        for (int i = 0; i < types.length; i++) {
-            templ[i] = new CKA(types[i], null);
-        }
 
-        // try getting all at once, first call to get how much memory we must allocate
-        GetAttributeValue(session, object, templ);
-        // allocate memory and go again
-        for (CKA att : templ) {
-            att.pValue = att.ulValueLen > 0 ? new byte[(int) att.ulValueLen] : null;
-        }
-        // Fill the allocated template with values (or no values for those that are empty or
-        // ATTRIBUTE_TYPE_INVALID or ATTRIBUTE_SENSITIVE
-        GetAttributeValue(session, object, templ);
-        return templ;
+        return new GetAttributeProcess(c, session, object, attributeLengthStrategy, attributeBatchModeEnabled, types).fetch();
     }
 
     /**
@@ -1880,5 +1870,41 @@ public class CryptokiE {
      */
     public NativeProviderMetrics getMetrics() {
         return c.getMetrics();
+    }
+
+    /**
+     * Set the strategy to use for getting the length of an attribute.
+     *
+     * @param attributeLengthStrategy the strategy to use for getting the length of an attribute
+     */
+    public void setAttributeLengthStrategy(AttributeLengthStrategy attributeLengthStrategy) {
+        this.attributeLengthStrategy = attributeLengthStrategy;
+    }
+
+    /**
+     * Get the strategy to use for getting the length of an attribute.
+     *
+     * @return the strategy to use for getting the length of an attribute
+     */
+    public AttributeLengthStrategy getAttributeLengthStrategy() {
+        return attributeLengthStrategy;
+    }
+
+    /**
+     * Set the mode to use for getting attribute values.
+     *
+     * @param attributeBatchModeEnabled if true, then batch mode is enabled
+     */
+    public void setAttributeBatchModeEnabled(boolean attributeBatchModeEnabled) {
+        this.attributeBatchModeEnabled = attributeBatchModeEnabled;
+    }
+
+    /**
+     * Get the mode to use for getting attribute values.
+     *
+     * @return if true, then batch mode is enabled
+     */
+    public boolean isAttributeBatchModeEnabled() {
+        return attributeBatchModeEnabled;
     }
 }

--- a/src/main/java/org/pkcs11/jacknji11/GetAttributeProcess.java
+++ b/src/main/java/org/pkcs11/jacknji11/GetAttributeProcess.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright 2010-2011 Joel Hockey (joel.hockey@gmail.com). All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.pkcs11.jacknji11;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Encapsulates attribute fetching process.
+ * <p>
+ * The process iteratively fetches all attributes.
+ * It operates either in batch mode or one-by-one.
+ * <p>
+ * The process is able to use max length of attribute instead of querying for attribute lengths,
+ * which can save some time by not issuing additional queries.
+ * <p>
+ * At worst case it will issue 3 queries to fetch a requested attribute, at best only 1.
+ * It is optimized for fetching many attributes at once (batch mode).
+ *
+ * @author Tomasz Wysocki
+ */
+class GetAttributeProcess {
+
+    /**
+     * Reference to cryptoki interface.
+     */
+    private final Cryptoki cryptoki;
+
+    /**
+     * Session to use for fetching.
+     */
+    private final long session;
+
+    /**
+     * Object to fetch attributes from.
+     */
+    private final long object;
+
+    /**
+     * Array of entries with fetch state.
+     */
+    private final Entry[] entries;
+
+    /**
+     * Indicator of attribute length strategy used for last query.
+     * <p>
+     * If <code>true</code> then last query used max length of attributes, and it is possible that buffer too small errors will occur.
+     * if <code>false</code> then last query lengths were not speculative and too small errors shall not occur.
+     */
+    private boolean maxLengthUsedInLastQuery;
+
+    /**
+     * Indicator for fetching mode.
+     * <p>
+     * If <code>true</code> then process fetches many attributes in one request.
+     * If <code>false</code> then attributes are fetched one by one.
+     */
+    private final boolean batchMode;
+
+    /**
+     * Internal class with state of fetch process for a single attribute
+     */
+    private static class Entry {
+
+        /**
+         * Type of attribute fetched.
+         */
+        private final long type;
+
+        /**
+         * Result of fetching the attribute.
+         */
+        private CKA cka;
+
+        /**
+         * Length of a buffer to use for fetching.
+         * if <code>0</code> then length is not known yet, and it will be queried instead of fetching the attribute.
+         */
+        private int length;
+
+        /**
+         * If <code>true</code> then the {@link #length} is actual known length of the attribute.
+         * If <code>false</code> then {@link #length} is set heuristically.
+         */
+        private boolean lengthKnown;
+
+        /**
+         * Create new entry for attribute.
+         *
+         * @param type  of attribute
+         * @param maxLength size of buffer to use for fetching, or <code>0</code> if length shall be established first.
+         */
+        Entry(long type, int maxLength) {
+            this.type = type;
+            this.length = maxLength;
+        }
+
+        /**
+         * @return true if length of the attribute is not known but a maximum value will be used.
+         */
+        public boolean isMaxLength() {
+            return !this.lengthKnown && this.length > 0;
+        }
+
+        /**
+         * Build query for fetching attribute.
+         *
+         * @return query for fetching attribute
+         */
+        private CKA query() {
+            if (this.length > 0) {
+                return CKA.allocate(this.type, this.length);
+            } else {
+                return CKA.indefinite(this.type);
+            }
+        }
+
+        /**
+         * Check if attribute was fetched.
+         *
+         * @return true if attribute was fetched.
+         */
+        public boolean isFetched() {
+            return getCka() != null;
+        }
+
+        /**
+         * Signal that allocation of buffer for fetching was too short.
+         */
+        public void bufferTooSmall() {
+            this.length = 0;
+            this.lengthKnown = false;
+        }
+
+        /**
+         * Set actual length of the attribute as returned from the provider.
+         *
+         * @param length of the attribute
+         */
+        public void setKnownLength(int length) {
+            this.length = length;
+            this.lengthKnown = true;
+        }
+
+        /**
+         * @return response from the fetch or null if not fetched yet.
+         */
+        public CKA getCka() {
+            return cka;
+        }
+
+        /**
+         * Set response from the fetch process.
+         *
+         * @param cka value of the attribute to be used as response.
+         */
+        public void setCka(CKA cka) {
+            this.cka = cka;
+        }
+    }
+
+    /**
+     * Construct new instance of the process.
+     *
+     * @param cryptoki reference to cryptoki interface
+     * @param session to use for fetching
+     * @param object to fetch attributes from
+     * @param attributeLengthStrategy strategy for getting attribute lengths
+     * @param batchMode if true then process fetches many attributes in one request, if false then attributes are fetched one by one
+     * @param types array of attributes to fetch
+     */
+    GetAttributeProcess(Cryptoki cryptoki, long session, long object, AttributeLengthStrategy attributeLengthStrategy, boolean batchMode, long... types) {
+        this.cryptoki = cryptoki;
+        this.session = session;
+        this.object = object;
+        this.batchMode = batchMode;
+        this.entries = new Entry[types.length];
+        for (int i = 0; i < types.length; i++) {
+            entries[i] = new Entry(types[i], attributeLengthStrategy.getAttributeLength(types[i]));
+        }
+    }
+
+    /**
+     * Build query for unfetched entries.
+     * <p>
+     * This method sets as a side effect {@link #maxLengthUsedInLastQuery} to indicate if max lengths were used in the query,
+     * which is used upon processing the response to determine if buffer too small errors are expected.
+     *
+     * @return query for unfetched entries.
+     */
+    private CKA[] buildQuery() {
+        List<CKA> query = new ArrayList<>();
+        boolean maxLengthsUsed = false;
+        for (Entry entry : entries) {
+            if (!entry.isFetched()) {
+                maxLengthsUsed |= entry.isMaxLength();
+                query.add(entry.query());
+                if (!batchMode) {
+                    break;
+                }
+            }
+        }
+        this.maxLengthUsedInLastQuery = maxLengthsUsed;
+        return query.toArray(new CKA[0]);
+    }
+
+    /**
+     * Get an entry for given attribute type.
+     *
+     * @param type of attribute
+     * @return entry for given attribute type
+     * @throws IllegalStateException if no such attribute type is present
+     */
+    private Entry getEntry(long type) {
+        for (Entry entry : entries) {
+            if (entry.type == type) {
+                return entry;
+            }
+        }
+        throw new IllegalStateException("No such attribute type: " + type);
+    }
+
+    /**
+     * Main method to fetch attributes.
+     *
+     * @return fetched attributes
+     * @throws CKRException if there is an error fetching attributes
+     */
+    CKA[] fetch() throws CKRException {
+
+        // this is query template that will be sent to the PKCS#11 interface
+        CKA[] query;
+        // loop for as long as there is anything to query
+        while ((query = buildQuery()).length > 0) {
+
+            // fetch attributes using query
+            long rv = cryptoki.GetAttributeValue(session, object, query);
+
+            // if there was an error indicated we need to process it
+            if (rv != CKR.OK) {
+                processError(rv, query);
+            }
+
+            // if we are here it means that there was no actual error,
+            // and we can extract available attributes
+            processAvailable(query);
+
+            // next iteration will either fetch rest of attributes or there is nothing to fetch
+        }
+
+        // return result from fetch process
+        return buildResult();
+    }
+
+    /**
+     * Process error result and response.
+     * <p>
+     * PKCS11 spec says:
+     * <quote>
+     * Note that the error codes CKR_ATTRIBUTE_SENSITIVE, CKR_ATTRIBUTE_TYPE_INVALID, and CKR_BUFFER_TOO_SMALL do not denote true errors for C_GetAttributeValue.
+     * </quote>
+     *
+     * @param rv       result of fetch operation
+     * @param response response from fetch operation
+     * @throws CKRException if there is an actual error fetching attributes
+     */
+    private void processError(long rv, CKA[] response) throws CKRException {
+        if (rv == CKR.BUFFER_TOO_SMALL) {
+            /*
+             This could happen if we are using max length strategy and max lengths are too small.
+             We assume here that all unavailable attributes are in fact reason for buffer too small
+             which depends on the provider implementation but this is how usually providers behave.
+             Even if some of them are actually invalid we will correct that in next iteration.
+            */
+            bufferTooSmall(response);
+        } else if (rv == CKR.ATTRIBUTE_SENSITIVE || rv == CKR.ATTRIBUTE_TYPE_INVALID) {
+            /*
+             If we have more than one unavailable attribute in response,
+             and we have been trying to speculatively use max length for attributes
+             then we cannot really tell if those attributes are invalid or buffer was too small.
+             Therefore, we will revert to querying for lengths first
+             and then fetching too small attributes in next iteration.
+             If there were no too small attributes we shall know that as well in next iteration
+             in which case it shall be the last one.
+            */
+            if (countUnavailable(response) > 1 && maxLengthUsedInLastQuery) {
+                bufferTooSmall(response);
+            } else {
+                attributesInvalid(response);
+            }
+        } else {
+            // any other error will be thrown as an exception
+            throw new CKRException("Error fetching " + listUnavailable(response) + " attributes, rv = "+rv, rv);
+        }
+    }
+
+    private String listUnavailable(CKA[] templ) {
+        StringBuilder sb = new StringBuilder();
+        for (CKA cka : templ) {
+            if (cka.ulValueLen == CK.UNAVAILABLE_INFORMATION) {
+                sb.append(cka.type).append(", ");
+            }
+        }
+        return sb.toString();
+    }
+
+    private int countUnavailable(CKA[] templ) {
+        int count = 0;
+        for (CKA cka : templ) {
+            if (cka.ulValueLen == CK.UNAVAILABLE_INFORMATION) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * @return build result from fetch process.
+     */
+    private CKA[] buildResult() {
+        CKA[] result = new CKA[entries.length];
+        for (int i = 0; i < entries.length; i++) {
+            result[i] = entries[i].getCka();
+        }
+        return result;
+    }
+
+    /**
+     * Process available attributes from the response.
+     * <p>
+     * Either an attribute is fetched or its length is now known.
+     *
+     * @param response to extract attributes from.
+     */
+    private void processAvailable(CKA[] response) {
+        for (CKA cka : response) {
+            Entry entry = getEntry(cka.type);
+            // valid attribute has length of 0, or it has a value
+            if (cka.ulValueLen == 0 || (cka.ulValueLen > 0 && cka.pValue != null)) {
+                // attribute is now fetched
+                entry.setCka(cka);
+            } else if (cka.ulValueLen > 0) {
+                // pValue is null but attribute size is now known
+                entry.setKnownLength((int) cka.ulValueLen);
+            }
+        }
+    }
+
+    /**
+     * Process unavailable attributes from the response as "buffer too small".
+     * <p>
+     * This will reset sizes all attributes that are unavailable to 0, causing their lengths to be
+     * queried first before fetching.
+     *
+     * @param response to extract attributes from.
+     */
+    private void bufferTooSmall(CKA[] response) {
+        for (CKA cka : response) {
+            Entry entry = getEntry(cka.type);
+            if (cka.ulValueLen == CK.UNAVAILABLE_INFORMATION) {
+                entry.bufferTooSmall();
+            }
+        }
+    }
+
+    /**
+     * Process unavailable attributes from the response as invalid.
+     * <p>
+     * This will use the resulting unavailable attributes as results (that are invalid).
+     *
+     * @param response to extract attributes from.
+     */
+    private void attributesInvalid(CKA[] response) {
+        for (CKA cka : response) {
+            Entry entry = getEntry(cka.type);
+            if (cka.ulValueLen == CK.UNAVAILABLE_INFORMATION) {
+                entry.setCka(cka);
+            }
+        }
+    }
+}

--- a/src/main/java/org/pkcs11/jacknji11/NativeProviderMetrics.java
+++ b/src/main/java/org/pkcs11/jacknji11/NativeProviderMetrics.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2010-2011 Joel Hockey (joel.hockey@gmail.com). All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.pkcs11.jacknji11;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.util.Collections.synchronizedMap;
+
+/**
+ * Metrics class keeps track of the number of attempts, duration and exceptions for each method in the {@link NativeProvider}.
+ * <p>
+ * To intercept the {@link NativeProvider}, the Metrics class uses a {@link Proxy} mechanism.
+ * <p>
+ * The keys of the metrics are the name of the methods from PKCS#11 spec (e.g. C_Initialize, C_Finalize, etc.). Use
+ * the constants from this class to access the metrics by method name.
+ * <p>
+ * The measurements are done using System.currentTimeMillis() and therefore are limited to the precision of the system clock.
+ *
+ * @author Tomasz Wysocki
+ */
+public class NativeProviderMetrics {
+
+    public static final String C_Initialize = "C_Initialize";
+    public static final String C_Finalize = "C_Finalize";
+    public static final String C_GetInfo = "C_GetInfo";
+    public static final String C_GetSlotList = "C_GetSlotList";
+    public static final String C_GetSlotInfo = "C_GetSlotInfo";
+    public static final String C_GetTokenInfo = "C_GetTokenInfo";
+    public static final String C_WaitForSlotEvent = "C_WaitForSlotEvent";
+    public static final String C_GetMechanismList = "C_GetMechanismList";
+    public static final String C_GetMechanismInfo = "C_GetMechanismInfo";
+    public static final String C_InitToken = "C_InitToken";
+    public static final String C_InitPIN = "C_InitPIN";
+    public static final String C_SetPIN = "C_SetPIN";
+    public static final String C_OpenSession = "C_OpenSession";
+    public static final String C_CloseSession = "C_CloseSession";
+    public static final String C_CloseAllSessions = "C_CloseAllSessions";
+    public static final String C_GetSessionInfo = "C_GetSessionInfo";
+    public static final String C_GetOperationState = "C_GetOperationState";
+    public static final String C_SetOperationState = "C_SetOperationState";
+    public static final String C_Login = "C_Login";
+    public static final String C_Logout = "C_Logout";
+    public static final String C_CreateObject = "C_CreateObject";
+    public static final String C_CopyObject = "C_CopyObject";
+    public static final String C_DestroyObject = "C_DestroyObject";
+    public static final String C_GetObjectSize = "C_GetObjectSize";
+    public static final String C_GetAttributeValue = "C_GetAttributeValue";
+    public static final String C_SetAttributeValue = "C_SetAttributeValue";
+    public static final String C_FindObjectsInit = "C_FindObjectsInit";
+    public static final String C_FindObjects = "C_FindObjects";
+    public static final String C_FindObjectsFinal = "C_FindObjectsFinal";
+    public static final String C_EncryptInit = "C_EncryptInit";
+    public static final String C_Encrypt = "C_Encrypt";
+    public static final String C_EncryptUpdate = "C_EncryptUpdate";
+    public static final String C_EncryptFinal = "C_EncryptFinal";
+    public static final String C_DecryptInit = "C_DecryptInit";
+    public static final String C_Decrypt = "C_Decrypt";
+    public static final String C_DecryptUpdate = "C_DecryptUpdate";
+    public static final String C_DecryptFinal = "C_DecryptFinal";
+    public static final String C_DigestInit = "C_DigestInit";
+    public static final String C_Digest = "C_Digest";
+    public static final String C_DigestUpdate = "C_DigestUpdate";
+    public static final String C_DigestKey = "C_DigestKey";
+    public static final String C_DigestFinal = "C_DigestFinal";
+    public static final String C_SignInit = "C_SignInit";
+    public static final String C_Sign = "C_Sign";
+    public static final String C_SignUpdate = "C_SignUpdate";
+    public static final String C_SignFinal = "C_SignFinal";
+    public static final String C_SignRecoverInit = "C_SignRecoverInit";
+    public static final String C_SignRecover = "C_SignRecover";
+    public static final String C_VerifyInit = "C_VerifyInit";
+    public static final String C_Verify = "C_Verify";
+    public static final String C_VerifyUpdate = "C_VerifyUpdate";
+    public static final String C_VerifyFinal = "C_VerifyFinal";
+    public static final String C_VerifyRecoverInit = "C_VerifyRecoverInit";
+    public static final String C_VerifyRecover = "C_VerifyRecover";
+    public static final String C_DigestEncryptUpdate = "C_DigestEncryptUpdate";
+    public static final String C_DecryptDigestUpdate = "C_DecryptDigestUpdate";
+    public static final String C_SignEncryptUpdate = "C_SignEncryptUpdate";
+    public static final String C_DecryptVerifyUpdate = "C_DecryptVerifyUpdate";
+    public static final String C_GenerateKey = "C_GenerateKey";
+    public static final String C_GenerateKeyPair = "C_GenerateKeyPair";
+    public static final String C_WrapKey = "C_WrapKey";
+    public static final String C_UnwrapKey = "C_UnwrapKey";
+    public static final String C_DeriveKey = "C_DeriveKey";
+    public static final String C_SeedRandom = "C_SeedRandom";
+    public static final String C_GenerateRandom = "C_GenerateRandom";
+    public static final String C_GetFunctionStatus = "C_GetFunctionStatus";
+    public static final String C_CancelFunction = "C_CancelFunction";
+
+    /**
+     * List of all metric entries per method.
+     */
+    private final Map<String, Entry> entries = new ConcurrentHashMap<>();
+
+    /**
+     * Entry for a method in the {@link NativeProvider}.
+     * <p>
+     * It keeps track of the number of attempts, duration and exceptions for the method.
+     */
+    private static class Entry {
+
+        // number of attempts the method was called (registered before the method is called)
+        AtomicInteger attempts;
+
+        // total duration of all attempts, only successful attempts are counted (those that have not thrown an exception)
+        AtomicLong duration;
+
+        // number of attempts per result (return value)
+        Map<Long, AtomicInteger> attemptsPerResult;
+
+        // total duration of all attempts per result (return value)
+        Map<Long, AtomicLong> durationPerResult;
+
+        // number of exceptions per exception class
+        Map<Class<?>, AtomicInteger> exceptions;
+
+        Entry() {
+            attempts = new AtomicInteger(0);
+            duration = new AtomicLong(0);
+            attemptsPerResult = synchronizedMap(new HashMap<>());
+            durationPerResult = synchronizedMap(new HashMap<>());
+            exceptions = synchronizedMap(new HashMap<>());
+        }
+
+        private void incDuration(long rv, long ms) {
+            duration(rv).addAndGet(ms);
+        }
+
+        private AtomicLong duration(long rv) {
+            return durationPerResult.computeIfAbsent(rv, k -> new AtomicLong(0));
+        }
+
+        private void incAttempts(long rv) {
+            attempts(rv).incrementAndGet();
+        }
+
+        private AtomicInteger attempts(long rv) {
+            return attemptsPerResult.computeIfAbsent(rv, k -> new AtomicInteger(0));
+        }
+
+        void incError(Class<?> exceptionClass) {
+            exceptionCounter(exceptionClass).incrementAndGet();
+        }
+
+        private AtomicInteger exceptionCounter(Class<?> exceptionClass) {
+            return exceptions.computeIfAbsent(exceptionClass, k -> new AtomicInteger(0));
+        }
+
+        int getAttempts() {
+            return attempts.get();
+        }
+
+        long getDuration() {
+            return duration.get();
+        }
+
+        int getAttempts(long rv) {
+            return attempts(rv).get();
+        }
+
+        int getExceptions(Class<?> exceptionClass) {
+            return exceptionCounter(exceptionClass).get();
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("  Attempts: ").append(attempts.get()).append("\n");
+
+            sb.append("  Duration: ").append(formatDuration(duration.get(), attempts.get())).append("\n");
+            for (Map.Entry<Long, AtomicInteger> entry : attemptsPerResult.entrySet()) {
+                int attempts = entry.getValue().intValue();
+                long duration = duration(entry.getKey()).get();
+                sb.append("  ");
+                sb.append(CKR.L2S(entry.getKey()));
+                sb.append(" -> ");
+                sb.append(attempts);
+                sb.append(" (");
+                sb.append(formatDuration(duration, attempts));
+                sb.append(")");
+                sb.append("\n");
+            }
+            for (Map.Entry<Class<?>, AtomicInteger> entry : exceptions.entrySet()) {
+                sb.append("Exception: ").append(entry.getKey()).append(" -> ").append(entry.getValue()).append("\n");
+            }
+            return sb.toString();
+        }
+
+        private String formatDuration(long duration, long attempts) {
+            return String.format("total: %dms avg: %4.2fms", duration, duration * 1.0 / attempts);
+        }
+
+        void result(long rv, long ms) {
+            this.duration.addAndGet(ms);
+            incAttempts(rv);
+            incDuration(rv, ms);
+        }
+
+        void incAttempts() {
+            attempts.incrementAndGet();
+        }
+    }
+
+    /**
+     * Reset all metrics.
+     */
+    public void reset() {
+        entries.clear();
+    }
+
+    /**
+     * Register a result for a method (after the method is called).
+     * @param method the name of the method
+     * @param rv the return value
+     * @param ms the duration of the method call in milliseconds
+     */
+    void registerResult(String method, long rv, long ms) {
+        getEntry(method).result(rv, ms);
+    }
+
+    /**
+     * Register an attempt for a method (before the method is called).
+     *
+     * @param method the name of the method
+     */
+    void registerAttempt(String method) {
+        getEntry(method).incAttempts();
+    }
+
+    /**
+     * Get or create an entry for a method.
+     *
+     * @param name the name of the method
+     * @return the entry for the method
+     */
+    private Entry getEntry(String name) {
+        return entries.computeIfAbsent(name, k -> new Entry());
+    }
+
+    /**
+     * Get the number of attempts for a method.
+     *
+     * @param method the name of the method
+     * @return the number of attempts
+     */
+    public int getAttempts(String method) {
+        return getEntry(method).getAttempts();
+    }
+
+    /**
+     * Get the number of attempts for a method and a specific return value.
+     *
+     * @param method the name of the method
+     * @param rv the return value
+     * @return the number of attempts
+     */
+    public int getAttempts(String method, long rv) {
+        return getEntry(method).getAttempts(rv);
+    }
+
+    /**
+     * Get total duration of all attempts for a method.
+     *
+     * @param method the name of the method
+     * @return the total duration of all attempts
+     */
+    public long getDuration(String method) {
+        return getEntry(method).getDuration();
+    }
+
+    /**
+     * Get total duration of all attempts for a method and a specific return value.
+     *
+     * @param method the name of the method
+     * @param rv the return value
+     * @return the total duration of all attempts for a method and a specific return value
+     */
+    public long getDuration(String method, long rv) {
+        return getEntry(method).duration(rv).get();
+    }
+
+    /**
+     * Get the number of exceptions for a method and a specific exception class.
+     *
+     * @param key the name of the method
+     * @param exceptionClass the exception class
+     * @return the number of exceptions
+     */
+    public int getExceptions(String key, Class<?> exceptionClass) {
+        return getEntry(key).getExceptions(exceptionClass);
+    }
+
+    /**
+     * Intercept given instance of NativeProvider by creating a proxy
+     * that will call the original methods and measure counts, duration and exceptions.
+     *
+     * @param nativeProvider the instance of NativeProvider to intercept
+     * @return the intercepted instance of NativeProvider (proxy)
+     */
+    NativeProvider intercept(NativeProvider nativeProvider) {
+        return (NativeProvider) Proxy.newProxyInstance(
+                nativeProvider.getClass().getClassLoader(),
+                new Class[]{NativeProvider.class},
+                (proxy, method, args) -> handleMethod(nativeProvider, method, args)
+        );
+    }
+
+    /**
+     * Catch all methods from NativeProvider starting with C_ and call {@link #handleCryptokiMethod(NativeProvider, Method, Object[])}.
+     *
+     * @param nativeProvider the instance of NativeProvider (original)
+     * @param method the method to call
+     * @param args the arguments for the method
+     * @return the result of the method
+     */
+    private Object handleMethod(NativeProvider nativeProvider, Method method, Object[] args) throws IllegalAccessException, InvocationTargetException {
+        // catch only methods from NativeProvider starting with C_
+        if (method.getDeclaringClass() == NativeProvider.class) {
+            if (method.getName().startsWith("C_")) {
+                return handleCryptokiMethod(nativeProvider, method, args);
+            }
+        }
+        return method.invoke(nativeProvider, args);
+    }
+
+    /**
+     * Handle the method call by calling the original method and measuring counts, duration and exceptions.
+     *
+     * @param nativeProvider the instance of NativeProvider (original)
+     * @param method the method to call
+     * @param args the arguments for the method
+     * @return the result of the method
+     */
+    private long handleCryptokiMethod(NativeProvider nativeProvider, Method method, Object[] args) throws IllegalAccessException, InvocationTargetException {
+        String name = method.getName();
+        try {
+            registerAttempt(name);
+            long s = System.currentTimeMillis();
+            // all C_ methods return long
+            long rv = (long) method.invoke(nativeProvider, args);
+            long e = System.currentTimeMillis();
+            registerResult(name, rv, e-s);
+            return rv;
+        } catch (RuntimeException exc) {
+            incError(name, exc.getClass());
+            throw exc;
+        }
+    }
+
+    /**
+     * Increment the number of exceptions for a method and a specific exception class.
+     *
+     * @param method the name of the method
+     * @param exceptionClass the exception class to increment
+     */
+    private void incError(String method, Class<?> exceptionClass) {
+        getEntry(method).incError(exceptionClass);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, Entry> entry : entries.entrySet()) {
+            sb.append(entry.getKey()).append(":\n");
+            sb.append(entry.getValue());
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/pkcs11/jacknji11/UBigInt.java
+++ b/src/main/java/org/pkcs11/jacknji11/UBigInt.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2010-2011 Joel Hockey (joel.hockey@gmail.com). All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.pkcs11.jacknji11;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+/**
+ * Utility class for encoding and decoding unsigned big integers in big-endian byte arrays.
+ * <p>
+ * Unsigned big integers are encoded as big-endian byte arrays without leading zero bytes.
+ *
+ * @author Tomasz Wysocki
+ */
+public class UBigInt {
+
+    private UBigInt() {
+        // utility class
+    }
+
+    /**
+     * Encode unsigned big integer to byte array.
+     *
+     * @param value unsigned big integer
+     * @return byte array with big-endian encoding without leading zero bytes,
+     * the size of the array is the minimum required to represent the value.
+     */
+    public static byte[] ubigint2b(BigInteger value) {
+        byte[] bytes = value.toByteArray();
+        // strip initial zero if present as we are operating on unsigned values
+        if (bytes.length > 1 && bytes[0] == 0) {
+            bytes = Arrays.copyOfRange(bytes, 1, bytes.length);
+        }
+        return bytes;
+    }
+
+    /**
+     * Decode unsigned big integer from byte array.
+     *
+     * @param bytes byte array with big-endian encoding of unsigned big integer (highest bit is not a sign bit)
+     * @return unsigned big integer
+     */
+    public static BigInteger b2ubigint(byte[] bytes) {
+        return new BigInteger(1, bytes);
+    }
+}

--- a/src/main/java/org/pkcs11/jacknji11/jna/Template.java
+++ b/src/main/java/org/pkcs11/jacknji11/jna/Template.java
@@ -115,7 +115,7 @@ public class Template extends PointerType {
             return;
         }
         int offset = 0;
-        for (int i = 0; i < list.length; i++) {
+        for (CKA cka : list) {
             offset += NativeLong.SIZE; // skip type
 
             // read pValue
@@ -133,9 +133,10 @@ public class Template extends PointerType {
 
             // read contents into pValue if ptr != null && ulValueLen > 0
             if (ptr != null && ulValueLen > 0) {
-                ptr.read(0, list[i].pValue, 0, ulValueLen);
+                ptr.read(0, cka.pValue, 0, ulValueLen);
             }
-            list[i].ulValueLen = ulValueLen;
+            cka.ulValueLen = ulValueLen;
+            cka.set();
         }
     }
 }

--- a/src/main/java/org/pkcs11/jacknji11/jna/Template.java
+++ b/src/main/java/org/pkcs11/jacknji11/jna/Template.java
@@ -51,6 +51,13 @@ public class Template extends PointerType {
     }
 
     /**
+     * @return number of attributes in this template
+     */
+    public int getListLen() {
+        return listLen;
+    }
+
+    /**
      * Allocates JNA Memory and writes CKA[] values.
      * @param list template
      */

--- a/src/test/java/org/pkcs11/jacknji11/CKATest.java
+++ b/src/test/java/org/pkcs11/jacknji11/CKATest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2010-2011 Joel Hockey (joel.hockey@gmail.com). All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.pkcs11.jacknji11;
+
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class CKATest {
+
+
+    @Test
+    public void testAllocate() {
+        CKA cka = CKA.allocate(CKA.MODULUS, 100);
+
+        // value is null because the buffer is not really set with anything
+        assertNull(cka.getValue());
+        assertEquals(100, cka.ulValueLen);
+        // however the pValue points at a buffer
+        assertNotNull(cka.pValue);
+
+        // it can also be checked by hasValue
+        assertFalse(cka.hasValue());
+
+        // to string should not display any value, however it shall display its allocated state
+        assertEquals(cka.toString(), "type=0x00000120{MODULUS}  ALLOCATED [100B]");
+
+        // now let's emulate setting the value (this happens when Cryptoki native structure is applied back onto CKA)
+        cka.set();
+
+        // value is no longer null
+        assertNotNull(cka.getValue());
+
+        // and value is set therfeore hasValue returns true
+        assertTrue(cka.hasValue());
+
+        // to string should now display the value and the BUFFERED state shall not be displayed
+        assertTrue(cka.toString().contains("type=0x00000120{MODULUS}  [100B]"));
+
+    }
+
+    @Test
+    public void testIndefinite() {
+        CKA cka = CKA.indefinite(CKA.VALUE);
+
+        // the CKA has no value
+        assertNull(cka.getValue());
+        // it also does not have a buffer
+        assertNull(cka.pValue);
+        // and the length is 0
+        assertEquals(0, cka.ulValueLen);
+
+        // it can also be checked by hasValue
+        assertFalse(cka.hasValue());
+
+        // to string should not display any value, however it shall display its indefinite state
+        assertEquals(cka.toString(), "type=0x00000011{VALUE}  INDEFINITE");
+
+        // let's emulate setting the value (this happens when Cryptoki native structure is applied back onto CKA)
+        // in this case as buffer is null, only the length is set
+        cka.set();
+        cka.ulValueLen = 100;
+
+        // value is still null
+        assertNull(cka.getValue());
+
+        // but the length is set
+        assertEquals(100, cka.ulValueLen);
+
+        // however hasValue still returns false (as there is actually no value set)
+        assertFalse(cka.hasValue());
+
+        // to string should now display the length and the INDEFINITE state shall not be displayed
+        assertEquals(cka.toString(), cka.toString(), "type=0x00000011{VALUE}  DEFINITE [100B]");
+
+    }
+
+    @Test
+    public void testEmpty() {
+        // lets create the empty attribute
+        CKA cka = new CKA(CKA.VALUE, null);
+
+        // the CKA has no value
+        assertNull(cka.getValue());
+        // it also does not have a buffer
+        assertNull(cka.pValue);
+        // and the length is 0
+        assertEquals(0, cka.ulValueLen);
+
+        // it can also be checked by hasValue
+        assertFalse(cka.hasValue());
+
+        // to string should not display any value, however it shall display its empty state
+        assertEquals(cka.toString(), "type=0x00000011{VALUE}  EMPTY");
+
+    }
+
+    @Test
+    public void testEmptyFromQuery() {
+        // lets create the buffered attribute
+        CKA cka = CKA.allocate(CKA.VALUE, 100);
+
+        // now let's set the empty state
+        cka.ulValueLen = 0;
+        cka.set();
+
+        // the CKA has no value
+        assertNull(cka.getValue());
+
+        // and the length is 0
+        assertEquals(0, cka.ulValueLen);
+
+        // it can also be checked by hasValue
+        assertFalse(cka.hasValue());
+
+        // to string should not display any value, however it shall display its empty state
+        assertEquals(cka.toString(), "type=0x00000011{VALUE}  EMPTY");
+
+    }
+
+    @Test
+    public void testBool() {
+        CKA cka = new CKA(CKA.SENSITIVE, true);
+
+        // we check the encoding
+        byte[] bytes = cka.getValue();
+        assertArrayEquals(new byte[]{1}, bytes);
+
+        // and the value
+        assertTrue(cka.getValueBool());
+
+        // now let's create this attribute from the encoding of value
+        CKA cka2 = new CKA(CKA.SENSITIVE, bytes);
+
+        // and check the value
+        assertTrue(cka2.getValueBool());
+
+        // and the encoded bytes (should be the same)
+        assertArrayEquals(new byte[]{1}, cka2.getValue());
+
+        // also while we have the object let's check the toString
+        assertTrue(cka.toString(), cka.toString().contains("type=0x00000103{SENSITIVE}  [1B] value=TRUE"));
+
+        assertEquals(cka, cka2);
+        assertEquals(cka.hashCode(), cka2.hashCode());
+    }
+
+    @Test
+    public void testULong() {
+        CKA cka = new CKA(CKA.VALUE_LEN, 100L);
+        byte[] expectedBytes = ULong.ulong2b(100L);
+
+        // we check the encoding
+        byte[] bytes = cka.getValue();
+        assertArrayEquals(expectedBytes, bytes);
+
+        // and the value
+        assertEquals(100L, cka.getValueLong().longValue());
+
+        // now let's create this attribute from the encoding of value
+        CKA cka2 = new CKA(CKA.VALUE_LEN, bytes);
+
+        // and check the value
+        assertEquals(100L, cka2.getValueLong().longValue());
+
+        // and the encoded bytes (should be the same)
+        assertArrayEquals(expectedBytes, cka2.getValue());
+
+        // also while we have the object let's check the toString
+        assertTrue(cka.toString(), cka.toString().contains("type=0x00000161{VALUE_LEN}  [4B] value=100"));
+
+        assertEquals(cka, cka2);
+        assertEquals(cka.hashCode(), cka2.hashCode());
+    }
+
+
+    @Test
+    public void testString() {
+        String expectedStr = "test";
+        byte[] expectedBytes = expectedStr.getBytes(StandardCharsets.US_ASCII);
+        CKA cka = new CKA(CKA.LABEL, expectedStr);
+
+        // we check the encoding
+        byte[] bytes = cka.getValue();
+        assertArrayEquals(expectedBytes, bytes);
+
+        // and the value
+        assertEquals(expectedStr, cka.getValueStr());
+
+        // now let's create this attribute from the encoding of value
+        CKA cka2 = new CKA(CKA.LABEL, bytes);
+
+        // and check the value
+        assertEquals(expectedStr, cka2.getValueStr());
+
+        // and the encoded bytes (should be the same)
+        assertArrayEquals(expectedBytes, cka2.getValue());
+
+        // also while we have the object let's check the toString
+        assertTrue(cka.toString(), cka.toString().contains("type=0x00000003{LABEL}  [4B] value=\"test\""));
+
+        assertEquals(cka, cka2);
+        assertEquals(cka.hashCode(), cka2.hashCode());
+
+    }
+
+    @Test
+    public void testBigInt() {
+
+        // the test value is taken directly from PKCS#11 spec
+        //        Big integer
+        //        a string of CK_BYTEs representing an unsigned integer of arbitrary size,
+        //        most-significant byte first (e.g., the integer 32768 is represented as the 2-byte string 0x80 0x00)
+        // this encoding when using two-complement encoding in big endian is a negative number
+        // therefore needs special handling
+
+        BigInteger expectedBint = BigInteger.valueOf(32768L);
+        byte[] expectedBytes = {(byte) 0x80, 0x00};
+
+        // lets create the attribute from value
+        CKA cka = new CKA(CKA.MODULUS, expectedBint);
+
+        // we check the encoding
+        byte[] bytes = cka.getValue();
+        assertArrayEquals(expectedBytes, bytes);
+
+        // and the value
+        BigInteger bint = cka.getValueBigInt();
+        assertEquals(expectedBint, bint);
+
+        // now let's create this attribute from the encoding of value
+        CKA cka2 = new CKA(CKA.MODULUS, bytes);
+
+        // and check the value
+        bint = cka2.getValueBigInt();
+        assertEquals(expectedBint, bint);
+
+        // and the encoded bytes (should be the same)
+        assertArrayEquals(expectedBytes, cka2.getValue());
+
+        // also while we have the object let's check the toString
+        assertTrue(cka.toString().contains("type=0x00000120{MODULUS}  [2B]"));
+        assertTrue(cka.toString().contains("80 00"));
+
+        assertEquals(cka, cka2);
+        assertEquals(cka.hashCode(), cka2.hashCode());
+    }
+
+
+}


### PR DESCRIPTION
This PR is collection of improvements I've done in order to support Luna HSM (avoiding Thales own provider).

Summary of changes:

1. Optimized the way attributes are read by using heuristic buffer sizes. This improves performance, especially for providers like Luna. The `toString` method now only shows relevant attribute data and the buffer logging doesn't dump on buffer too small errors.

2. Added metrics that are intercepted by the NativeProvider proxy. These metrics capture various data for each function, such as total count of attempts, count of attempts per result, total duration, sum of duration per result, and count of runtime exceptions per exception class.

3. Made `listLen` from the `Template` class accessible. This allows it to be rendered as part of other native structures.

4. Fixed copy and paste for `CKC`.

5. Added more `CKM` mechanisms and other `KDF` and `WRAP` constants. Also added a `CK` class with a couple of common constants.

6. Improved `CKM` by changing `paramLen` in the constructor to `long` to avoid casts and warnings. Now you can pass a `Memory` object directly instead of a pointer and len. The `toString` method now prints `pParameter` instead of `bParameter`.

7. Changed `CKA` bigint operations to use unsigned values as per the PKCS#11 spec.

8. Added a sources jar.