### PR TITLE
Fix alignment in JNA_CKM and JNA_CK_C_INITIALIZE_ARGS on Win64

### DIFF
--- a/src/main/java/org/pkcs11/jacknji11/jna/JNA_CKM.java
+++ b/src/main/java/org/pkcs11/jacknji11/jna/JNA_CKM.java
@@ -26,7 +26,6 @@ import org.pkcs11.jacknji11.CKM;
 import java.util.Arrays;
 import java.util.List;
 
-import com.sun.jna.Memory;
 import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
@@ -40,6 +39,12 @@ public class JNA_CKM extends Structure {
     public NativeLong mechanism;
     public Pointer pParameter;
     public NativeLong ulParameterLen;
+
+    public JNA_CKM() {
+        // Need to set alignment to none since 'pParameter' is not
+        // aligned to a 8 byte boundary on Win64 (long is 4 bytes there)
+        super(ALIGN_NONE);
+    }
 
     @Override
     protected List<String> getFieldOrder() {

--- a/src/main/java/org/pkcs11/jacknji11/jna/JNA_CK_C_INITIALIZE_ARGS.java
+++ b/src/main/java/org/pkcs11/jacknji11/jna/JNA_CK_C_INITIALIZE_ARGS.java
@@ -57,6 +57,10 @@ public class JNA_CK_C_INITIALIZE_ARGS extends Structure {
     }
 
     public JNA_CK_C_INITIALIZE_ARGS(final CK_C_INITIALIZE_ARGS args) {
+        // Need to set alignment to none. Otherwise there would be alignment
+        // padding before 'pReserved' on Win64 (there, long is 4 bytes but
+        // pointers have 8 byte alignment)
+        super(ALIGN_NONE);
         if (args.createMutex != null) {
             this.createMutex = new JNA_CK_CREATEMUTEX() {
                 public long invoke(NativePointerByReference mutex) {


### PR DESCRIPTION
On 64-bit Windows, the long type is 4 bytes and pointers are 8 bytes. This leads to a padding hole in the `JNA_CKM` structure, between the `mechanism` and the `pParameter` fields. That's not in accordance to the spec, which says that 1-byte alignment shall be used (section 2.1 in PKCS#11 v. 3.1). In practice, it causes signing with RSASSA-PSS padding to fail on Win64.

There is also a similar problem in `JNA_CK_C_INITIALIZE_ARGS`. It does not seem to cause any issues in practice, though.

This PR fixes both alignment issues for JNA.

P.S. There's probably the same issue with JFFI. I think it could be fixed by calling `super(jnr.ffi.Runtime.getSystemRuntime(), Struct.Alignment(1))`, but that constructor is only available in a later version of jnr-jffi. And that version has some API changes that require refactoring (JFFINative would have to be changed to an interface).